### PR TITLE
Feature/exec from mount

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
         file: ./Containerfile
         push: true
         tags: quay.io/armosec/kubecop:${{ env.TAG_NAME }}
+        platforms: linux/amd64,linux/arm64
 
   create-release:
     needs: build-and-push

--- a/chart/kubecop/crds/runtime-rule-binding.crd.yaml
+++ b/chart/kubecop/crds/runtime-rule-binding.crd.yaml
@@ -97,10 +97,11 @@ spec:
                       - R0003
                       - R0004
                       - R0005
+                      - R1000
                       - R1001
                       - R1002
                       - R1003
-                      - R1000
+                      - R1004
                       type: string
                     ruleName:
                       enum:
@@ -113,6 +114,7 @@ spec:
                       - Kernel Module Load
                       - Exec Binary Not In Base Image
                       - Malicious SSH Connection
+                      - Exec from mount
                       type: string
                     ruleTags:
                       items:
@@ -124,6 +126,7 @@ spec:
                         - signature
                         - syscall
                         - whitelisted
+                        - mount
                         - ssh
                         type: string
                       type: array

--- a/pkg/engine/rule/README.md
+++ b/pkg/engine/rule/README.md
@@ -1,15 +1,12 @@
-# Rules
-
-## Rule list
-
 | ID | Rule | Description | Tags | Priority | Application profile |
 |----|------|-------------|------|----------|---------------------|
-| R0001 | Unexpected process launched | Detecting exec calls that are not whitelisted by application profile | [Unexpected process launched] | 7 | true |
+| R0001 | Unexpected process launched | Detecting exec calls that are not whitelisted by application profile | [exec whitelisted] | 7 | true |
 | R0002 | Unexpected file access | Detecting file access that are not whitelisted by application profile. File access is defined by the combination of path and flags | [open whitelisted] | 5 | true |
 | R0003 | Unexpected system call | Detecting unexpected system calls that are not whitelisted by application profile. Every unexpected system call will be alerted only once. | [syscall whitelisted] | 7 | true |
 | R0004 | Unexpected capability used | Detecting unexpected capabilities that are not whitelisted by application profile. Every unexpected capability is identified in context of a syscall and will be alerted only once per container. | [capabilities whitelisted] | 8 | true |
 | R0005 | Unexpected domain request | Detecting unexpected domain requests that are not whitelisted by application profile. | [dns whitelisted] | 6 | true |
-| R1001 | Exec Binary Not In Base Image | Detecting exec calls of binaries that are not included in the base image | [exec malicious binary base image] | 7 | false |
+| R1000 | Exec from malicious source | Detecting exec calls that are from malicious source like: /dev/shm, /run, /var/run, /proc/self | [exec signature] | 9 | false |
+| R1001 | Exec Binary Not In Base Image | Detecting exec calls of binaries that are not included in the base image | [exec malicious binary base image] | 9 | false |
 | R1002 | Kernel Module Load | Detecting Kernel Module Load. | [syscall kernel module load] | 7 | false |
 | R1003 | Malicious SSH Connection | Detecting ssh connection to disallowed port | [ssh connection port malicious] | 7 | false |
-| R1000 | Exec from malicious source | Detecting exec calls that are from malicious source like: /dev/shm, /run, /var/run, /proc/self | [exec signature] | 9 | false |
+| R1004 | Exec from mount | Detecting exec calls from mounted paths. | [exec mount] | 5 | false |

--- a/pkg/engine/rule/factory.go
+++ b/pkg/engine/rule/factory.go
@@ -7,10 +7,11 @@ var ruleDescriptions []RuleDesciptor = []RuleDesciptor{
 	R0003UnexpectedSystemCallRuleDescriptor,
 	R0004UnexpectedCapabilityUsedRuleDescriptor,
 	R0005UnexpectedDomainRequestRuleDescriptor,
+	R1000ExecFromMaliciousSourceDescriptor,
 	R1001ExecBinaryNotInBaseImageRuleDescriptor,
 	R1002LoadKernelModuleRuleDescriptor,
 	R1003MaliciousSSHConnectionRuleDescriptor,
-	R1000ExecFromMaliciousSourceDescriptor,
+	R1004ExecFromMountRuleDescriptor,
 }
 
 func GetAllRuleDescriptors() []RuleDesciptor {

--- a/pkg/engine/rule/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/engine/rule/r1001_exec_binary_not_in_base_image.go
@@ -23,7 +23,7 @@ var R1001ExecBinaryNotInBaseImageRuleDescriptor = RuleDesciptor{
 	Name:        R1001ExecBinaryNotInBaseImageRuleName,
 	Description: "Detecting exec calls of binaries that are not included in the base image",
 	Tags:        []string{"exec", "malicious", "binary", "base image"},
-	Priority:    7,
+	Priority:    9,
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.ExecveEventType},
 		NeedApplicationProfile: false,

--- a/pkg/engine/rule/r1004_exec_from_mount.go
+++ b/pkg/engine/rule/r1004_exec_from_mount.go
@@ -1,0 +1,157 @@
+package rule
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/armosec/kubecop/pkg/approfilecache"
+	"github.com/kubescape/kapprofiler/pkg/tracing"
+)
+
+const (
+	R1004ID                    = "R1004"
+	R1004ExecFromMountRuleName = "Exec from mount"
+)
+
+var R1004ExecFromMountRuleDescriptor = RuleDesciptor{
+	ID:          R1004ID,
+	Name:        R1004ExecFromMountRuleName,
+	Description: "Detecting exec calls from mounted paths.",
+	Tags:        []string{"exec", "mount"},
+	Priority:    5,
+	Requirements: RuleRequirements{
+		EventTypes:             []tracing.EventType{tracing.ExecveEventType},
+		NeedApplicationProfile: false,
+	},
+	RuleCreationFunc: func() Rule {
+		return CreateRuleR1004ExecFromMount()
+	},
+}
+
+type R1004ExecFromMount struct {
+	BaseRule
+	// Map of container ID to mount paths
+	mutex                   sync.RWMutex
+	containerIdToMountPaths map[string][]string
+}
+
+type R1004ExecFromMountFailure struct {
+	RuleName         string
+	RulePriority     int
+	Err              string
+	FixSuggestionMsg string
+	FailureEvent     *tracing.ExecveEvent
+}
+
+func (rule *R1004ExecFromMount) Name() string {
+	return R1004ExecFromMountRuleName
+}
+
+func CreateRuleR1004ExecFromMount() *R1004ExecFromMount {
+	return &R1004ExecFromMount{
+		containerIdToMountPaths: map[string][]string{},
+	}
+}
+
+func (rule *R1004ExecFromMount) DeleteRule() {
+}
+
+func (rule *R1004ExecFromMount) ProcessEvent(eventType tracing.EventType, event interface{}, appProfileAccess approfilecache.SingleApplicationProfileAccess, engineAccess EngineAccess) RuleFailure {
+	if eventType != tracing.ExecveEventType {
+		return nil
+	}
+
+	execEvent, ok := event.(*tracing.ExecveEvent)
+	if !ok {
+		return nil
+	}
+
+	rule.mutex.RLock()
+	mounts, ok := rule.containerIdToMountPaths[execEvent.ContainerID]
+	rule.mutex.RUnlock()
+	if !ok {
+		err := rule.setMountPaths(execEvent.PodName, execEvent.Namespace, execEvent.ContainerID, execEvent.ContainerName, engineAccess)
+		if err != nil {
+			log.Printf("Failed to set mount paths: %v", err)
+			return nil
+		}
+		rule.mutex.RLock()
+		mounts = rule.containerIdToMountPaths[execEvent.ContainerID]
+		rule.mutex.RUnlock()
+	}
+
+	for _, mount := range mounts {
+		contained := rule.isPathContained(execEvent.PathName, mount)
+		if contained {
+			if os.Getenv("DEBUG") == "true" {
+				log.Printf("Path %s is mounted in pod %s/%s", execEvent.PathName, execEvent.Namespace, execEvent.PodName)
+			}
+			return &R1004ExecFromMountFailure{
+				RuleName:         rule.Name(),
+				Err:              "Exec from mount",
+				FailureEvent:     execEvent,
+				FixSuggestionMsg: "If this is a legitimate action, please consider removing this workload from the binding of this rule",
+				RulePriority:     R1004ExecFromMountRuleDescriptor.Priority,
+			}
+		}
+	}
+
+	return nil
+
+}
+
+func (rule *R1004ExecFromMount) setMountPaths(podName string, namespace string, containerID string, containerName string, engineAccess EngineAccess) error {
+	podSpec, err := engineAccess.GetPodSpec(podName, namespace, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to get pod spec: %v", err)
+	}
+
+	mountPaths := []string{}
+	for _, container := range podSpec.Containers {
+		if container.Name == containerName {
+			for _, volumeMount := range container.VolumeMounts {
+				mountPaths = append(mountPaths, volumeMount.MountPath)
+			}
+		}
+	}
+
+	rule.mutex.Lock()
+	defer rule.mutex.Unlock()
+	rule.containerIdToMountPaths[containerID] = mountPaths
+
+	return nil
+}
+
+func (rule *R1004ExecFromMount) isPathContained(targetpath, basepath string) bool {
+	return strings.HasPrefix(targetpath, basepath)
+}
+
+func (rule *R1004ExecFromMount) Requirements() RuleRequirements {
+	return RuleRequirements{
+		EventTypes:             []tracing.EventType{tracing.OpenEventType},
+		NeedApplicationProfile: true,
+	}
+}
+
+func (rule *R1004ExecFromMountFailure) Name() string {
+	return rule.RuleName
+}
+
+func (rule *R1004ExecFromMountFailure) Error() string {
+	return rule.Err
+}
+
+func (rule *R1004ExecFromMountFailure) Event() tracing.GeneralEvent {
+	return rule.FailureEvent.GeneralEvent
+}
+
+func (rule *R1004ExecFromMountFailure) Priority() int {
+	return rule.RulePriority
+}
+
+func (rule *R1004ExecFromMountFailure) FixSuggestion() string {
+	return rule.FixSuggestionMsg
+}

--- a/pkg/engine/rule/r1004_exec_from_mount.go
+++ b/pkg/engine/rule/r1004_exec_from_mount.go
@@ -131,8 +131,8 @@ func (rule *R1004ExecFromMount) isPathContained(targetpath, basepath string) boo
 
 func (rule *R1004ExecFromMount) Requirements() RuleRequirements {
 	return RuleRequirements{
-		EventTypes:             []tracing.EventType{tracing.OpenEventType},
-		NeedApplicationProfile: true,
+		EventTypes:             []tracing.EventType{tracing.ExecveEventType},
+		NeedApplicationProfile: false,
 	}
 }
 

--- a/pkg/engine/rule/r1004_exec_from_mount_test.go
+++ b/pkg/engine/rule/r1004_exec_from_mount_test.go
@@ -1,0 +1,43 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/kubescape/kapprofiler/pkg/tracing"
+)
+
+func TestR1004ExecFromMount(t *testing.T) {
+	// Create a new rule
+	r := CreateRuleR1004ExecFromMount()
+	// Assert r is not nil
+	if r == nil {
+		t.Errorf("Expected r to not be nil")
+	}
+	// Create a exec event
+	e := &tracing.ExecveEvent{
+		GeneralEvent: tracing.GeneralEvent{
+			ContainerID:   "test",
+			ContainerName: "test",
+			PodName:       "test",
+			Namespace:     "test",
+			Timestamp:     0,
+		},
+		PathName: "/test",
+		Args:     []string{"test"},
+	}
+
+	// Test case where path is not mounted
+	ruleResult := r.ProcessEvent(tracing.ExecveEventType, e, nil, &EngineAccessMock{})
+	if ruleResult != nil {
+		t.Errorf("Expected ruleResult to be nil since test is not from a mounted path")
+	}
+
+	// Test case where path is mounted
+
+	e.PathName = "/var/test1/test"
+
+	ruleResult = r.ProcessEvent(tracing.ExecveEventType, e, nil, &EngineAccessMock{})
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult since exec is from a mounted path")
+	}
+}

--- a/pkg/rulebindingstore/crd.yaml
+++ b/pkg/rulebindingstore/crd.yaml
@@ -97,10 +97,11 @@ spec:
                       - R0003
                       - R0004
                       - R0005
+                      - R1000
                       - R1001
                       - R1002
                       - R1003
-                      - R1000
+                      - R1004
                       type: string
                     ruleName:
                       enum:
@@ -109,10 +110,11 @@ spec:
                       - Unexpected system call
                       - Unexpected capability used
                       - Unexpected domain request
+                      - Exec from malicious source
                       - Exec Binary Not In Base Image
                       - Kernel Module Load
                       - Malicious SSH Connection
-                      - Exec from malicious source
+                      - Exec from mount
                       type: string
                     ruleTags:
                       items:
@@ -127,13 +129,15 @@ spec:
                         - load
                         - malicious
                         - module
+                        - mount
                         - open
                         - port
                         - signature
                         - ssh
                         - syscall
                         - whitelisted
-                        type: string
-                      type: array
+    served: false
+    storage: false
+ray
     served: false
     storage: false

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-all-pods.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-all-pods.yaml
@@ -15,3 +15,4 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
+    - ruleName: "Exec from mount"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx-default-ns.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx-default-ns.yaml
@@ -22,3 +22,4 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
+    - ruleName: "Exec from mount"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx.yaml
@@ -16,3 +16,4 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
+    - ruleName: "Exec from mount"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-default-ns.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-default-ns.yaml
@@ -16,3 +16,4 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
+    - ruleName: "Exec from mount"


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR introduces a new rule, 'Exec from mount', and integrates it into the existing system. The main changes include:
- Adding the 'Exec from mount' rule which detects exec calls from mounted paths.
- Updating the rule priority of 'Exec Binary Not In Base Image' from 7 to 9.
- Integrating the new rule into the rule list in 'factory.go'.
- Updating the rule list in the README and in the CRD files.
- Adding a test file for the new rule.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `pkg/engine/rule/r1004_exec_from_mount.go`: This file contains the implementation of the new 'Exec from mount' rule. It includes the rule descriptor, the rule struct, and the methods associated with the rule.
- `pkg/engine/rule/factory.go`: The new rule has been added to the rule list in this file.
- `pkg/engine/rule/r1001_exec_binary_not_in_base_image.go`: The priority of the 'Exec Binary Not In Base Image' rule has been updated from 7 to 9.
- `pkg/engine/rule/r1004_exec_from_mount_test.go`: This file contains the tests for the new 'Exec from mount' rule.
- `chart/kubecop/crds/runtime-rule-binding.crd.yaml`: The new rule has been added to the CRD file.
- `pkg/engine/rule/README.md`: The README has been updated to include the new rule in the rule list.
- `pkg/rulebindingstore/crd.yaml`: The new rule has been added to the CRD file.
- `pkg/rulebindingstore/testdata/rulebindingsfiles/*.yaml`: The new rule has been added to the rule list in the test data files.
</details>
