### PR TITLE
Adding k8s client rule - version 1

### DIFF
--- a/chart/kubecop/crds/runtime-rule-binding.crd.yaml
+++ b/chart/kubecop/crds/runtime-rule-binding.crd.yaml
@@ -97,10 +97,11 @@ spec:
                       - R0003
                       - R0004
                       - R0005
+                      - R1000
                       - R1001
                       - R1002
                       - R1003
-                      - R1000
+                      - R1005
                       type: string
                     ruleName:
                       enum:
@@ -113,6 +114,7 @@ spec:
                       - Kernel Module Load
                       - Exec Binary Not In Base Image
                       - Malicious SSH Connection
+                      - Kubernetes Client Executed
                       type: string
                     ruleTags:
                       items:

--- a/pkg/engine/rule/factory.go
+++ b/pkg/engine/rule/factory.go
@@ -7,10 +7,11 @@ var ruleDescriptions []RuleDesciptor = []RuleDesciptor{
 	R0003UnexpectedSystemCallRuleDescriptor,
 	R0004UnexpectedCapabilityUsedRuleDescriptor,
 	R0005UnexpectedDomainRequestRuleDescriptor,
+	R1000ExecFromMaliciousSourceDescriptor,
 	R1001ExecBinaryNotInBaseImageRuleDescriptor,
 	R1002LoadKernelModuleRuleDescriptor,
 	R1003MaliciousSSHConnectionRuleDescriptor,
-	R1000ExecFromMaliciousSourceDescriptor,
+	R1005KubernetesClientExecutedDescriptor,
 }
 
 func GetAllRuleDescriptors() []RuleDesciptor {

--- a/pkg/engine/rule/r0001_unexpected_process_launched.go
+++ b/pkg/engine/rule/r0001_unexpected_process_launched.go
@@ -23,7 +23,7 @@ var R0001UnexpectedProcessLaunchedRuleDescriptor = RuleDesciptor{
 		NeedApplicationProfile: true,
 	},
 	RuleCreationFunc: func() Rule {
-		return CreateRuleR0001UnexpectedProcessLaunched()
+		return CreateRuleR1005KubernetesClientExecution()
 	},
 }
 
@@ -43,7 +43,7 @@ func (rule *R0001UnexpectedProcessLaunched) Name() string {
 	return R0001UnexpectedProcessLaunchedRuleName
 }
 
-func CreateRuleR0001UnexpectedProcessLaunched() *R0001UnexpectedProcessLaunched {
+func CreateRuleR1005KubernetesClientExecution() *R0001UnexpectedProcessLaunched {
 	return &R0001UnexpectedProcessLaunched{}
 }
 

--- a/pkg/engine/rule/r0001_unexpected_process_launched_test.go
+++ b/pkg/engine/rule/r0001_unexpected_process_launched_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestR0001UnexpectedProcessLaunched(t *testing.T) {
 	// Create a new rule
-	r := CreateRuleR0001UnexpectedProcessLaunched()
+	r := CreateRuleR1005KubernetesClientExecution()
 	// Assert r is not nil
 	if r == nil {
 		t.Errorf("Expected r to not be nil")

--- a/pkg/engine/rule/r1000_exec_from_malicious_source.go
+++ b/pkg/engine/rule/r1000_exec_from_malicious_source.go
@@ -24,7 +24,7 @@ var R1000ExecFromMaliciousSourceDescriptor = RuleDesciptor{
 		NeedApplicationProfile: false,
 	},
 	RuleCreationFunc: func() Rule {
-		return CreateRuleR0001UnexpectedProcessLaunched()
+		return CreateRuleR1005KubernetesClientExecution()
 	},
 }
 

--- a/pkg/engine/rule/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/engine/rule/r1001_exec_binary_not_in_base_image.go
@@ -73,7 +73,7 @@ func (rule *R1001ExecBinaryNotInBaseImage) ProcessEvent(eventType tracing.EventT
 	return &R1001ExecBinaryNotInBaseImageFailure{
 		RuleName:         rule.Name(),
 		Err:              fmt.Sprintf("Process image \"%s\" binary is not from the container image \"%s\"", execEvent.PathName, "<image name TBA> via PodSpec"),
-		FixSuggestionMsg: fmt.Sprintf("If this is an expected behavior it is strongly suggested to include all executables in the container image. If this is not possible you can remove the rule binding to this workload."),
+		FixSuggestionMsg: "If this is an expected behavior it is strongly suggested to include all executables in the container image. If this is not possible you can remove the rule binding to this workload.",
 		FailureEvent:     execEvent,
 		RulePriority:     R1001ExecBinaryNotInBaseImageRuleDescriptor.Priority,
 	}

--- a/pkg/engine/rule/r1005_kubernetes_client_executed.go
+++ b/pkg/engine/rule/r1005_kubernetes_client_executed.go
@@ -1,0 +1,124 @@
+package rule
+
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"slices"
+
+	"github.com/armosec/kubecop/pkg/approfilecache"
+	"github.com/kubescape/kapprofiler/pkg/tracing"
+)
+
+const (
+	R1005ID                               = "R1005"
+	R1005KubernetesClientExecutedRuleName = "Kubernetes Client Executed"
+)
+
+var KubernetesClients = []string{
+	"kubectl",
+	"kubeadm",
+	"kubelet",
+	"kube-proxy",
+	"kube-apiserver",
+	"kube-controller-manager",
+	"kube-scheduler",
+	"crictl",
+	"docker",
+	"containerd",
+	"runc",
+	"ctr",
+	"containerd-shim",
+	"containerd-shim-runc-v2",
+	"containerd-shim-runc-v1",
+	"containerd-shim-runc-v0",
+	"containerd-shim-runc",
+}
+
+var R1005KubernetesClientExecutedDescriptor = RuleDesciptor{
+	ID:          R1005ID,
+	Name:        R1005KubernetesClientExecutedRuleName,
+	Description: "Detecting exececution of kubernetes client",
+	Priority:    9,
+	Tags:        []string{"exec", "malicious"},
+	Requirements: RuleRequirements{
+		EventTypes:             []tracing.EventType{tracing.ExecveEventType},
+		NeedApplicationProfile: false,
+	},
+	RuleCreationFunc: func() Rule {
+		return CreateRuleR1005KubernetesClientExecution()
+	},
+}
+
+type R1005KubernetesClientExecuted struct {
+}
+
+type R1005KubernetesClientExecutedFailure struct {
+	RuleName         string
+	RulePriority     int
+	FixSuggestionMsg string
+	Err              string
+	FailureEvent     *tracing.ExecveEvent
+}
+
+func (rule *R1005KubernetesClientExecuted) Name() string {
+	return R1005KubernetesClientExecutedRuleName
+}
+
+func CreateRuleR1005KubernetesClientExecuted() *R1005KubernetesClientExecuted {
+	return &R1005KubernetesClientExecuted{}
+}
+
+func (rule *R1005KubernetesClientExecuted) DeleteRule() {
+}
+
+func (rule *R1005KubernetesClientExecuted) ProcessEvent(eventType tracing.EventType, event interface{}, appProfileAccess approfilecache.SingleApplicationProfileAccess, engineAccess EngineAccess) RuleFailure {
+	if eventType != tracing.ExecveEventType {
+		return nil
+	}
+
+	execEvent, ok := event.(*tracing.ExecveEvent)
+	if !ok {
+		return nil
+	}
+
+	if slices.Contains(KubernetesClients, filepath.Base(execEvent.PathName)) {
+		log.Printf("Kubernetes client executed: %s", filepath.Base(execEvent.PathName))
+		return &R1005KubernetesClientExecutedFailure{
+			RuleName:         rule.Name(),
+			Err:              fmt.Sprintf("Kubernetes client executed: %s", execEvent.PathName),
+			FixSuggestionMsg: "If this is a legitimate action, please consider removing this workload from the binding of this rule.",
+			FailureEvent:     execEvent,
+			RulePriority:     R1005KubernetesClientExecutedDescriptor.Priority,
+		}
+	}
+
+	return nil
+}
+
+func (rule *R1005KubernetesClientExecuted) Requirements() RuleRequirements {
+	return RuleRequirements{
+		EventTypes:             []tracing.EventType{tracing.ExecveEventType},
+		NeedApplicationProfile: false,
+	}
+}
+
+func (rule *R1005KubernetesClientExecutedFailure) Name() string {
+	return rule.RuleName
+}
+
+func (rule *R1005KubernetesClientExecutedFailure) Error() string {
+	return rule.Err
+}
+
+func (rule *R1005KubernetesClientExecutedFailure) Event() tracing.GeneralEvent {
+	return rule.FailureEvent.GeneralEvent
+}
+
+func (rule *R1005KubernetesClientExecutedFailure) Priority() int {
+	return rule.RulePriority
+}
+
+func (rule *R1005KubernetesClientExecutedFailure) FixSuggestion() string {
+	return rule.FixSuggestionMsg
+}

--- a/pkg/engine/rule/r1005_kubernetes_client_executed_test.go
+++ b/pkg/engine/rule/r1005_kubernetes_client_executed_test.go
@@ -1,0 +1,46 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/kubescape/kapprofiler/pkg/tracing"
+)
+
+func TestR1005KubernetesClientExecuted(t *testing.T) {
+	// Create a new rule
+	r := CreateRuleR1005KubernetesClientExecuted()
+	// Assert r is not nil
+	if r == nil {
+		t.Errorf("Expected r to not be nil")
+	}
+	// Create a exec event
+	e := &tracing.ExecveEvent{
+		GeneralEvent: tracing.GeneralEvent{
+			ContainerID: "test",
+			PodName:     "test",
+			Namespace:   "test",
+			Timestamp:   0,
+		},
+		PathName: "/test",
+		Args:     []string{"test"},
+	}
+
+	ruleResult := r.ProcessEvent(tracing.ExecveEventType, e, nil, &EngineAccessMock{})
+	if ruleResult != nil {
+		t.Errorf("Expected ruleResult to be nil since test is not a k8s client")
+	}
+
+	e.PathName = "kubectl"
+
+	ruleResult = r.ProcessEvent(tracing.ExecveEventType, e, nil, &EngineAccessMock{})
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult since exec is a k8s client")
+	}
+
+	e.PathName = "/a/b/c/kubectl"
+
+	ruleResult = r.ProcessEvent(tracing.ExecveEventType, e, nil, &EngineAccessMock{})
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult since exec is a k8s client")
+	}
+}

--- a/pkg/rulebindingstore/crd.yaml
+++ b/pkg/rulebindingstore/crd.yaml
@@ -97,10 +97,11 @@ spec:
                       - R0003
                       - R0004
                       - R0005
+                      - R1000
                       - R1001
                       - R1002
                       - R1003
-                      - R1000
+                      - R1005
                       type: string
                     ruleName:
                       enum:
@@ -109,10 +110,11 @@ spec:
                       - Unexpected system call
                       - Unexpected capability used
                       - Unexpected domain request
+                      - Exec from malicious source
                       - Exec Binary Not In Base Image
                       - Kernel Module Load
                       - Malicious SSH Connection
-                      - Exec from malicious source
+                      - Kubernetes Client Executed
                       type: string
                     ruleTags:
                       items:
@@ -133,7 +135,8 @@ spec:
                         - ssh
                         - syscall
                         - whitelisted
-                        type: string
+    served: false
+    storage: false
                       type: array
     served: false
     storage: false

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-all-pods.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-all-pods.yaml
@@ -15,3 +15,4 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
+    - ruleName: "Kubernetes Client Executed"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx-default-ns.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx-default-ns.yaml
@@ -22,3 +22,4 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
+    - ruleName: "Kubernetes Client Executed"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx.yaml
@@ -16,3 +16,4 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
+    - ruleName: "Kubernetes Client Executed"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-default-ns.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-default-ns.yaml
@@ -16,3 +16,4 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
+    - ruleName: "Kubernetes Client Executed"


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR introduces a new rule to detect the execution of Kubernetes clients. The rule, identified as R1005, is designed to flag instances where Kubernetes clients such as kubectl, kubeadm, kubelet, etc., are executed. This can help in identifying potential security issues or misconfigurations. The rule is added to the rule descriptors and is also reflected in the relevant test files and YAML configurations.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `pkg/engine/rule/r1005_kubernetes_client_executed.go`: This file contains the main implementation of the new rule. It defines the rule descriptor, the list of Kubernetes clients to monitor, and the rule's behavior when processing events. If a Kubernetes client is executed, a failure event is generated with an appropriate error message and fix suggestion.
- `pkg/engine/rule/r1005_kubernetes_client_executed_test.go`: This file contains the tests for the new rule. It checks the rule's behavior when a Kubernetes client is executed and when a non-Kubernetes client is executed.
- `pkg/engine/rule/factory.go`: The new rule R1005 is added to the list of rule descriptors.
- `chart/kubecop/crds/runtime-rule-binding.crd.yaml`: The new rule R1005 is added to the list of rule IDs and rule names in the Kubernetes Custom Resource Definition (CRD).
- `pkg/rulebindingstore/crd.yaml`: The new rule R1005 is added to the list of rule IDs and rule names in the CRD for the rule binding store.
- `pkg/rulebindingstore/testdata/rulebindingsfiles/`: The new rule R1005 is added to the list of rules in various rule binding files for testing purposes.
</details>
