### PR TITLE
Adding title to alert manager messages

### DIFF
--- a/pkg/engine/rule/r0005_unexpected_domain_request.go
+++ b/pkg/engine/rule/r0005_unexpected_domain_request.go
@@ -105,7 +105,7 @@ func (rule *R0005UnexpectedDomainRequest) ProcessEvent(eventType tracing.EventTy
 				domainEvent.PodName,
 				rule.generatePatchCommand(domainEvent, appProfileAccess)),
 			FailureEvent: domainEvent,
-			RulePriority: RulePrioritySystemIssue,
+			RulePriority: RulePriorityMed,
 		}
 	}
 

--- a/pkg/exporters/alert_manager.go
+++ b/pkg/exporters/alert_manager.go
@@ -54,11 +54,13 @@ func (ame *AlertManagerExporter) SendAlert(failedRule rule.RuleFailure) {
 		failedRule.Event().ContainerName,
 		fmt.Sprintf("%s (%d)", failedRule.Event().Comm, failedRule.Event().Pid),
 	)
+	summary := fmt.Sprintf("Rule '%s' in '%s' namespace '%s' failed", failedRule.Name(), failedRule.Event().PodName, failedRule.Event().Namespace)
 	myAlert := models.PostableAlert{
 		StartsAt: strfmt.DateTime(time.Now()),
 		EndsAt:   strfmt.DateTime(time.Now().Add(time.Hour)),
 		Annotations: map[string]string{
-			"summary":     fmt.Sprintf("Rule '%s' in '%s' namespace '%s' failed", failedRule.Name(), failedRule.Event().PodName, failedRule.Event().Namespace),
+			"title":       summary,
+			"summary":     summary,
 			"message":     failedRule.Error(),
 			"description": failedRule.Error(),
 			"fix":         failedRule.FixSuggestion(),


### PR DESCRIPTION
## type:
Enhancement, Refactoring

___
## description:
This PR introduces two main changes:
- A title is added to the alert manager messages, providing a concise summary of the alert.
- The priority of the DNS whitelisting tool is adjusted from 'SystemIssue' to 'Medium'.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `pkg/engine/rule/r0005_unexpected_domain_request.go`: The priority of the DNS whitelisting tool has been adjusted from 'SystemIssue' to 'Medium'.
- `pkg/exporters/alert_manager.go`: A 'title' field has been added to the alert manager messages. The title is a formatted string that provides a summary of the alert.
</details>

___
## User Description:
Cosmetic changes:
* adding title field to Alert manager messages
* Fixing the priority of the DNS  whitelisting tool
