### PR TITLE
Preventing from using incomplete application profiles

### DIFF
--- a/pkg/approfilecache/cache.go
+++ b/pkg/approfilecache/cache.go
@@ -98,6 +98,11 @@ func (cache *ApplicationProfileK8sCache) LoadApplicationProfile(namespace, kind,
 	if err != nil {
 		return err
 	}
+	if applicationProfile.GetAnnotations()["kapprofiler.kubescape.io/final"] != "true" {
+		// The application profile is not final, return an error
+		return fmt.Errorf("application profile %s is not final", applicationProfile.GetName())
+	}
+
 	cache.cache[containerID] = &ApplicationProfileCacheEntry{
 		ApplicationProfile: applicationProfile,
 		WorkloadName:       workloadName,


### PR DESCRIPTION
## type:
bug_fix

___
## description:
This PR addresses a bug in KubeCop where it was previously able to load incomplete application profiles at container start time. The fix involves adding a check to ensure that the application profile is final before loading it. If the application profile is not final, an error is returned.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `pkg/approfilecache/cache.go`: Added a check in the LoadApplicationProfile function to ensure that the application profile is final before loading it. If the application profile is not final, an error is returned. This prevents KubeCop from loading incomplete application profiles.
</details>

___
## User Description:
Preventing KubeCop from loading incomplete application profiles at container start time
