### PR TITLE
Fixing rules priorities

### DIFF
--- a/pkg/engine/rule/r0001_unexpected_process_launched.go
+++ b/pkg/engine/rule/r0001_unexpected_process_launched.go
@@ -17,7 +17,7 @@ var R0001UnexpectedProcessLaunchedRuleDescriptor = RuleDesciptor{
 	Name:        R0001UnexpectedProcessLaunchedRuleName,
 	Description: "Detecting exec calls that are not whitelisted by application profile",
 	Tags:        []string{"exec", "whitelisted"},
-	Priority:    7,
+	Priority:    RulePriorityCritical,
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.ExecveEventType},
 		NeedApplicationProfile: true,
@@ -81,7 +81,7 @@ func (rule *R0001UnexpectedProcessLaunched) ProcessEvent(eventType tracing.Event
 			Err:              "Application profile is missing",
 			FailureEvent:     execEvent,
 			FixSuggestionMsg: fmt.Sprintf("Please create an application profile for the Pod \"%s\" and add the exec call \"%s\" to the whitelist", execEvent.PodName, execEvent.PathName),
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0001UnexpectedProcessLaunchedRuleDescriptor.Priority,
 		}
 	}
 
@@ -92,7 +92,7 @@ func (rule *R0001UnexpectedProcessLaunched) ProcessEvent(eventType tracing.Event
 			Err:              "Application profile is missing",
 			FailureEvent:     execEvent,
 			FixSuggestionMsg: fmt.Sprintf("Please create an application profile for the Pod \"%s\" and add the exec call \"%s\" to the whitelist", execEvent.PodName, execEvent.PathName),
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0001UnexpectedProcessLaunchedRuleDescriptor.Priority,
 		}
 	}
 

--- a/pkg/engine/rule/r0002_unexpected_file_access.go
+++ b/pkg/engine/rule/r0002_unexpected_file_access.go
@@ -21,7 +21,7 @@ var R0002UnexpectedFileAccessRuleDescriptor = RuleDesciptor{
 	Name:        R0002UnexpectedFileAccessRuleName,
 	Description: "Detecting file access that are not whitelisted by application profile. File access is defined by the combination of path and flags",
 	Tags:        []string{"open", "whitelisted"},
-	Priority:    5,
+	Priority:    RulePriorityMed,
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.OpenEventType},
 		NeedApplicationProfile: true,
@@ -122,7 +122,7 @@ func (rule *R0002UnexpectedFileAccess) ProcessEvent(eventType tracing.EventType,
 			Err:              "Application profile is missing",
 			FixSuggestionMsg: fmt.Sprintf("Please create an application profile for the Pod %s", openEvent.PodName),
 			FailureEvent:     openEvent,
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0002UnexpectedFileAccessRuleDescriptor.Priority,
 		}
 	}
 
@@ -133,7 +133,7 @@ func (rule *R0002UnexpectedFileAccess) ProcessEvent(eventType tracing.EventType,
 			Err:              "Application profile is missing",
 			FixSuggestionMsg: fmt.Sprintf("Please create an application profile for the Pod %s", openEvent.PodName),
 			FailureEvent:     openEvent,
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0002UnexpectedFileAccessRuleDescriptor.Priority,
 		}
 	}
 

--- a/pkg/engine/rule/r0003_unexpected_system_call.go
+++ b/pkg/engine/rule/r0003_unexpected_system_call.go
@@ -19,7 +19,7 @@ var R0003UnexpectedSystemCallRuleDescriptor = RuleDesciptor{
 	Name:        R0003UnexpectedSystemCallRuleName,
 	Description: "Detecting unexpected system calls that are not whitelisted by application profile. Every unexpected system call will be alerted only once.",
 	Tags:        []string{"syscall", "whitelisted"},
-	Priority:    7,
+	Priority:    RulePriorityMed,
 	Requirements: RuleRequirements{
 		EventTypes: []tracing.EventType{
 			tracing.SyscallEventType,
@@ -81,7 +81,7 @@ func (rule *R0003UnexpectedSystemCall) ProcessEvent(eventType tracing.EventType,
 			Err:              "Application profile is missing",
 			FixSuggestionMsg: fmt.Sprintf("Please create an application profile for the Pod %s", syscallEvent.PodName),
 			FailureEvent:     syscallEvent,
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0003UnexpectedSystemCallRuleDescriptor.Priority,
 		}
 	}
 
@@ -92,7 +92,7 @@ func (rule *R0003UnexpectedSystemCall) ProcessEvent(eventType tracing.EventType,
 			Err:              "Application profile is missing (missing syscall list))",
 			FixSuggestionMsg: fmt.Sprintf("Please create an application profile for the Pod %s", syscallEvent.PodName),
 			FailureEvent:     syscallEvent,
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0003UnexpectedSystemCallRuleDescriptor.Priority,
 		}
 	}
 

--- a/pkg/engine/rule/r0004_unexpected_capability_used.go
+++ b/pkg/engine/rule/r0004_unexpected_capability_used.go
@@ -17,7 +17,7 @@ var R0004UnexpectedCapabilityUsedRuleDescriptor = RuleDesciptor{
 	Name:        R0004UnexpectedCapabilityUsedRuleName,
 	Description: "Detecting unexpected capabilities that are not whitelisted by application profile. Every unexpected capability is identified in context of a syscall and will be alerted only once per container.",
 	Tags:        []string{"capabilities", "whitelisted"},
-	Priority:    8,
+	Priority:    RulePriorityHigh,
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.CapabilitiesEventType},
 		NeedApplicationProfile: true,
@@ -72,7 +72,7 @@ func (rule *R0004UnexpectedCapabilityUsed) ProcessEvent(eventType tracing.EventT
 			Err:              "Application profile is missing",
 			FixSuggestionMsg: fmt.Sprintf("Please create an application profile for the Pod %s", capEvent.PodName),
 			FailureEvent:     capEvent,
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0004UnexpectedCapabilityUsedRuleDescriptor.Priority,
 		}
 	}
 
@@ -83,7 +83,7 @@ func (rule *R0004UnexpectedCapabilityUsed) ProcessEvent(eventType tracing.EventT
 			Err:              "Application profile is missing",
 			FixSuggestionMsg: fmt.Sprintf("Please create an application profile for the Pod %s", capEvent.PodName),
 			FailureEvent:     capEvent,
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0004UnexpectedCapabilityUsedRuleDescriptor.Priority,
 		}
 	}
 

--- a/pkg/engine/rule/r0005_unexpected_domain_request.go
+++ b/pkg/engine/rule/r0005_unexpected_domain_request.go
@@ -17,7 +17,7 @@ var R0005UnexpectedDomainRequestRuleDescriptor = RuleDesciptor{
 	Name:        R0005UnexpectedDomainRequestRuleName,
 	Description: "Detecting unexpected domain requests that are not whitelisted by application profile.",
 	Tags:        []string{"dns", "whitelisted"},
-	Priority:    6,
+	Priority:    RulePriorityMed,
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.DnsEventType},
 		NeedApplicationProfile: true,
@@ -72,7 +72,7 @@ func (rule *R0005UnexpectedDomainRequest) ProcessEvent(eventType tracing.EventTy
 			Err:              "Application profile is missing",
 			FixSuggestionMsg: fmt.Sprintf("Create an application profile with the domain %s", domainEvent.DnsName),
 			FailureEvent:     domainEvent,
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0005UnexpectedDomainRequestRuleDescriptor.Priority,
 		}
 	}
 
@@ -83,7 +83,7 @@ func (rule *R0005UnexpectedDomainRequest) ProcessEvent(eventType tracing.EventTy
 			Err:              "Application profile is missing",
 			FixSuggestionMsg: fmt.Sprintf("Create an application profile with the domain %s", domainEvent.DnsName),
 			FailureEvent:     domainEvent,
-			RulePriority:     RulePrioritySystemIssue,
+			RulePriority:     R0005UnexpectedDomainRequestRuleDescriptor.Priority,
 		}
 	}
 
@@ -105,7 +105,7 @@ func (rule *R0005UnexpectedDomainRequest) ProcessEvent(eventType tracing.EventTy
 				domainEvent.PodName,
 				rule.generatePatchCommand(domainEvent, appProfileAccess)),
 			FailureEvent: domainEvent,
-			RulePriority: RulePriorityMed,
+			RulePriority: R0005UnexpectedDomainRequestRuleDescriptor.Priority,
 		}
 	}
 

--- a/pkg/engine/rule/r1000_exec_from_malicious_source.go
+++ b/pkg/engine/rule/r1000_exec_from_malicious_source.go
@@ -17,7 +17,7 @@ var R1000ExecFromMaliciousSourceDescriptor = RuleDesciptor{
 	ID:          R1000ID,
 	Name:        R1000ExecFromMaliciousSourceRuleName,
 	Description: "Detecting exec calls that are from malicious source like: /dev/shm, /run, /var/run, /proc/self",
-	Priority:    9,
+	Priority:    RulePriorityCritical,
 	Tags:        []string{"exec", "signature"},
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.ExecveEventType},

--- a/pkg/engine/rule/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/engine/rule/r1001_exec_binary_not_in_base_image.go
@@ -23,7 +23,7 @@ var R1001ExecBinaryNotInBaseImageRuleDescriptor = RuleDesciptor{
 	Name:        R1001ExecBinaryNotInBaseImageRuleName,
 	Description: "Detecting exec calls of binaries that are not included in the base image",
 	Tags:        []string{"exec", "malicious", "binary", "base image"},
-	Priority:    9,
+	Priority:    RulePriorityCritical,
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.ExecveEventType},
 		NeedApplicationProfile: false,

--- a/pkg/engine/rule/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/engine/rule/r1001_exec_binary_not_in_base_image.go
@@ -147,7 +147,9 @@ func getOverlayMountPoint(process *procfs.Proc) (string, error) {
 func fileExists(filePath string) bool {
 	info, err := os.Stat(filepath.Join("/host", filePath))
 	if os.IsNotExist(err) {
-		log.Printf("File %s does not exist %s \n", filePath, err)
+		if os.Getenv("DEBUG") == "true" {
+			log.Printf("File %s does not exist %s \n", filePath, err)
+		}
 		return false
 	}
 

--- a/pkg/engine/rule/r1002_load_kernel_module.go
+++ b/pkg/engine/rule/r1002_load_kernel_module.go
@@ -17,7 +17,7 @@ var R1002LoadKernelModuleRuleDescriptor = RuleDesciptor{
 	Name:        R1002LoadKernelModuleRuleName,
 	Description: "Detecting Kernel Module Load.",
 	Tags:        []string{"syscall", "kernel", "module", "load"},
-	Priority:    7,
+	Priority:    RulePriorityCritical,
 	Requirements: RuleRequirements{
 		EventTypes: []tracing.EventType{
 			tracing.SyscallEventType,

--- a/pkg/engine/rule/r1003_malicious_ssh_connection.go
+++ b/pkg/engine/rule/r1003_malicious_ssh_connection.go
@@ -46,7 +46,7 @@ var R1003MaliciousSSHConnectionRuleDescriptor = RuleDesciptor{
 	Name:        R1003MaliciousSSHConnectionRuleName,
 	Description: "Detecting ssh connection to disallowed port",
 	Tags:        []string{"ssh", "connection", "port", "malicious"},
-	Priority:    7,
+	Priority:    RulePriorityHigh,
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.OpenEventType, tracing.NetworkEventType},
 		NeedApplicationProfile: false,

--- a/pkg/engine/rule/r1004_exec_from_mount.go
+++ b/pkg/engine/rule/r1004_exec_from_mount.go
@@ -21,7 +21,7 @@ var R1004ExecFromMountRuleDescriptor = RuleDesciptor{
 	Name:        R1004ExecFromMountRuleName,
 	Description: "Detecting exec calls from mounted paths.",
 	Tags:        []string{"exec", "mount"},
-	Priority:    5,
+	Priority:    RulePriorityMed,
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.ExecveEventType},
 		NeedApplicationProfile: false,

--- a/pkg/engine/rule/r1005_kubernetes_client_executed.go
+++ b/pkg/engine/rule/r1005_kubernetes_client_executed.go
@@ -39,7 +39,7 @@ var R1005KubernetesClientExecutedDescriptor = RuleDesciptor{
 	ID:          R1005ID,
 	Name:        R1005KubernetesClientExecutedRuleName,
 	Description: "Detecting exececution of kubernetes client",
-	Priority:    9,
+	Priority:    RulePriorityCritical,
 	Tags:        []string{"exec", "malicious"},
 	Requirements: RuleRequirements{
 		EventTypes:             []tracing.EventType{tracing.ExecveEventType, tracing.NetworkEventType},

--- a/pkg/engine/rule/rule.go
+++ b/pkg/engine/rule/rule.go
@@ -12,7 +12,7 @@ const (
 	RulePriorityLow         = 1
 	RulePriorityMed         = 5
 	RulePriorityHigh        = 8
-	RulePriorityCrical      = 10
+	RulePriorityCritical    = 10
 	RulePrioritySystemIssue = 1000
 )
 

--- a/pkg/exporters/utils.go
+++ b/pkg/exporters/utils.go
@@ -12,7 +12,7 @@ func PriorityToStatus(priority int) string {
 		return "medium"
 	case rule.RulePriorityHigh:
 		return "high"
-	case rule.RulePriorityCrical:
+	case rule.RulePriorityCritical:
 		return "critical"
 	case rule.RulePrioritySystemIssue:
 		return "system_issue"
@@ -21,7 +21,7 @@ func PriorityToStatus(priority int) string {
 			return "low"
 		} else if priority < rule.RulePriorityHigh {
 			return "medium"
-		} else if priority < rule.RulePriorityCrical {
+		} else if priority < rule.RulePriorityCritical {
 			return "high"
 		}
 		return "unknown"

--- a/pkg/exporters/utils_test.go
+++ b/pkg/exporters/utils_test.go
@@ -34,7 +34,7 @@ func TestPriorityToStatus(t *testing.T) {
 		},
 		{
 			name:     "critical",
-			priority: rule.RulePriorityCrical,
+			priority: rule.RulePriorityCritical,
 			want:     "critical",
 		},
 		{
@@ -59,7 +59,7 @@ func TestPriorityToStatus(t *testing.T) {
 		},
 		{
 			name:     "high2",
-			priority: rule.RulePriorityCrical - 1,
+			priority: rule.RulePriorityCritical - 1,
 			want:     "high",
 		},
 	}


### PR DESCRIPTION
## type:
Refactoring

___
## description:
This PR focuses on refactoring the rule priorities in the codebase. The changes include:
- Replacing hardcoded rule priorities with constants.
- Correcting a typo in the rule priority constant name from 'RulePriorityCrical' to 'RulePriorityCritical'.
- Updating the rule priorities in various rule descriptors.
- Adjusting the rule priorities in the event processing functions.
- Modifying the 'PriorityToStatus' function and its test cases to reflect the changes in rule priorities.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `pkg/engine/rule/rule.go`: Corrected a typo in the rule priority constant name from 'RulePriorityCrical' to 'RulePriorityCritical'.
- `pkg/engine/rule/r0001_unexpected_process_launched.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityCritical' in the rule descriptor and event processing function.
- `pkg/engine/rule/r0002_unexpected_file_access.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityMed' in the rule descriptor and event processing function.
- `pkg/engine/rule/r0003_unexpected_system_call.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityMed' in the rule descriptor and event processing function.
- `pkg/engine/rule/r0004_unexpected_capability_used.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityHigh' in the rule descriptor and event processing function.
- `pkg/engine/rule/r0005_unexpected_domain_request.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityMed' in the rule descriptor and event processing function.
- `pkg/engine/rule/r1000_exec_from_malicious_source.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityCritical' in the rule descriptor.
- `pkg/engine/rule/r1001_exec_binary_not_in_base_image.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityCritical' in the rule descriptor.
- `pkg/engine/rule/r1002_load_kernel_module.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityCritical' in the rule descriptor.
- `pkg/engine/rule/r1003_malicious_ssh_connection.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityHigh' in the rule descriptor.
- `pkg/engine/rule/r1004_exec_from_mount.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityMed' in the rule descriptor.
- `pkg/engine/rule/r1005_kubernetes_client_executed.go`: Replaced the hardcoded rule priority with the constant 'RulePriorityCritical' in the rule descriptor.
- `pkg/exporters/utils.go`: Updated the 'PriorityToStatus' function to reflect the changes in rule priorities.
- `pkg/exporters/utils_test.go`: Updated the test cases for the 'PriorityToStatus' function to reflect the changes in rule priorities.
</details>
