### PR TITLE
Feature/r1007 crypto miner

### DIFF
--- a/chart/kubecop/crds/runtime-rule-binding.crd.yaml
+++ b/chart/kubecop/crds/runtime-rule-binding.crd.yaml
@@ -104,6 +104,7 @@ spec:
                       - R1004
                       - R1005
                       - R1006
+                      - R1007
                       type: string
                     ruleName:
                       enum:
@@ -119,6 +120,7 @@ spec:
                       - Kubernetes Client Executed
                       - Exec from mount
                       - Unshare System Call usage
+                      - Crypto Miners
                       type: string
                     ruleTags:
                       items:
@@ -133,6 +135,7 @@ spec:
                         - mount
                         - ssh
                         - escape
+                        - crypto
                         type: string
                       type: array
                     severity:

--- a/pkg/engine/rule/README.md
+++ b/pkg/engine/rule/README.md
@@ -12,3 +12,4 @@
 | R1004 | Exec from mount | Detecting exec calls from mounted paths. | [exec mount] | 5 | false |
 | R1005 | Kubernetes Client Executed | Detecting exececution of kubernetes client | [exec malicious] | 10 | false |
 | R1006 | Unshare System Call usage | Detecting Unshare System Call usage. | [syscall escape unshare] | 8 | false |
+| R1007 | Crypto Miners | Detecting Crypto Miners. | [network crypto miners malicious] | 8 | false |

--- a/pkg/engine/rule/factory.go
+++ b/pkg/engine/rule/factory.go
@@ -14,6 +14,7 @@ var ruleDescriptions []RuleDesciptor = []RuleDesciptor{
 	R1004ExecFromMountRuleDescriptor,
 	R1005KubernetesClientExecutedDescriptor,
 	R1006UnshareSyscallRuleDescriptor,
+	R1007CryptoMinersRuleDescriptor,
 }
 
 func GetAllRuleDescriptors() []RuleDesciptor {

--- a/pkg/engine/rule/r1007_crypto_miners.go
+++ b/pkg/engine/rule/r1007_crypto_miners.go
@@ -1,0 +1,111 @@
+package rule
+
+import (
+	"slices"
+
+	"github.com/armosec/kubecop/pkg/approfilecache"
+	"github.com/kubescape/kapprofiler/pkg/tracing"
+)
+
+// Current rule:
+// Detecting Crypto Miners by looking for outgoing TCP connections to commonly used crypto miners ports.
+// TODO: Add more crypto miners ports + add more crypto miners detection methods (e.g. by looking for specific processes and domains).
+
+const (
+	R1007ID                   = "R1007"
+	R1007CryptoMinersRuleName = "Crypto Miners"
+)
+
+var CommonlyUsedCryptoMinersPorts = []uint16{
+	3333, // Monero (XMR) - Stratum mining protocol (TCP).
+}
+
+var R1007CryptoMinersRuleDescriptor = RuleDesciptor{
+	ID:          R1007ID,
+	Name:        R1007CryptoMinersRuleName,
+	Description: "Detecting Crypto Miners.",
+	Tags:        []string{"network", "crypto", "miners", "malicious"},
+	Priority:    RulePriorityHigh,
+	Requirements: RuleRequirements{
+		EventTypes: []tracing.EventType{
+			tracing.NetworkEventType,
+		},
+		NeedApplicationProfile: false,
+	},
+	RuleCreationFunc: func() Rule {
+		return CreateRuleR1007CryptoMiners()
+	},
+}
+
+type R1007CryptoMiners struct {
+	BaseRule
+}
+
+type R1007CryptoMinersFailure struct {
+	RuleName         string
+	RulePriority     int
+	Err              string
+	FixSuggestionMsg string
+	FailureEvent     *tracing.NetworkEvent
+}
+
+func (rule *R1007CryptoMiners) Name() string {
+	return R1007CryptoMinersRuleName
+}
+
+func CreateRuleR1007CryptoMiners() *R1007CryptoMiners {
+	return &R1007CryptoMiners{}
+}
+
+func (rule *R1007CryptoMiners) DeleteRule() {
+}
+
+func (rule *R1007CryptoMiners) ProcessEvent(eventType tracing.EventType, event interface{}, appProfileAccess approfilecache.SingleApplicationProfileAccess, engineAccess EngineAccess) RuleFailure {
+	if eventType != tracing.NetworkEventType {
+		return nil
+	}
+
+	networkEvent, ok := event.(*tracing.NetworkEvent)
+	if !ok {
+		return nil
+	}
+
+	if networkEvent.Protocol == "TCP" && networkEvent.PacketType == "OUTGOING" && slices.Contains(CommonlyUsedCryptoMinersPorts, networkEvent.Port) {
+		return &R1007CryptoMinersFailure{
+			RuleName:         rule.Name(),
+			Err:              "Possible Crypto Miner detected",
+			FailureEvent:     networkEvent,
+			FixSuggestionMsg: "If this is a legitimate action, please consider removing this workload from the binding of this rule.",
+			RulePriority:     R1007CryptoMinersRuleDescriptor.Priority,
+		}
+	}
+
+	return nil
+}
+
+func (rule *R1007CryptoMiners) Requirements() RuleRequirements {
+	return RuleRequirements{
+		EventTypes:             []tracing.EventType{tracing.NetworkEventType},
+		NeedApplicationProfile: false,
+	}
+}
+
+func (rule *R1007CryptoMinersFailure) Name() string {
+	return rule.RuleName
+}
+
+func (rule *R1007CryptoMinersFailure) Error() string {
+	return rule.Err
+}
+
+func (rule *R1007CryptoMinersFailure) Event() tracing.GeneralEvent {
+	return rule.FailureEvent.GeneralEvent
+}
+
+func (rule *R1007CryptoMinersFailure) Priority() int {
+	return rule.RulePriority
+}
+
+func (rule *R1007CryptoMinersFailure) FixSuggestion() string {
+	return rule.FixSuggestionMsg
+}

--- a/pkg/engine/rule/r1007_crypto_miners_test.go
+++ b/pkg/engine/rule/r1007_crypto_miners_test.go
@@ -1,0 +1,49 @@
+package rule
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kubescape/kapprofiler/pkg/tracing"
+)
+
+func TestR1007CryptoMiners(t *testing.T) {
+	// Create a new rule
+	r := CreateRuleR1007CryptoMiners()
+	// Assert r is not nil
+	if r == nil {
+		t.Errorf("Expected r to not be nil")
+	}
+
+	// Create network event
+	e := &tracing.NetworkEvent{
+		GeneralEvent: tracing.GeneralEvent{
+			ContainerID: "test",
+			PodName:     "test",
+			Namespace:   "test",
+			Timestamp:   0,
+		},
+		PacketType:  "OUTGOING",
+		Protocol:    "TCP",
+		Port:        2222,
+		DstEndpoint: "1.1.1.1",
+	}
+
+	ruleResult := r.ProcessEvent(tracing.NetworkEventType, e, nil, nil)
+	if ruleResult != nil {
+		fmt.Printf("ruleResult: %v\n", ruleResult)
+		t.Errorf("Expected ruleResult to be nil since dst port is not in the commonly used crypto miners ports")
+		return
+	}
+
+	// Create network event with dst port 3333
+	e.Port = 3333
+
+	ruleResult = r.ProcessEvent(tracing.NetworkEventType, e, nil, nil)
+	if ruleResult == nil {
+		fmt.Printf("ruleResult: %v\n", ruleResult)
+		t.Errorf("Expected ruleResult to be Failure because of dst port is in the commonly used crypto miners ports")
+		return
+	}
+
+}

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-all-pods.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-all-pods.yaml
@@ -18,3 +18,4 @@ spec:
     - ruleName: "Kubernetes Client Executed"
     - ruleName: "Exec from mount"
     - ruleName: "Unshare System Call usage"
+    - ruleName: "Crypto Miners"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx-default-ns.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx-default-ns.yaml
@@ -25,3 +25,4 @@ spec:
     - ruleName: "Kubernetes Client Executed"
     - ruleName: "Exec from mount"
     - ruleName: "Unshare System Call usage"
+    - ruleName: "Crypto Miners"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-app-nginx.yaml
@@ -19,3 +19,4 @@ spec:
     - ruleName: "Kubernetes Client Executed"
     - ruleName: "Exec from mount"
     - ruleName: "Unshare System Call usage"
+    - ruleName: "Crypto Miners"

--- a/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-default-ns.yaml
+++ b/pkg/rulebindingstore/testdata/rulebindingsfiles/all-rules-for-default-ns.yaml
@@ -19,3 +19,4 @@ spec:
     - ruleName: "Kubernetes Client Executed"
     - ruleName: "Exec from mount"
     - ruleName: "Unshare System Call usage"
+    - ruleName: "Crypto Miners"


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR introduces a new rule to detect Crypto Miners in the system. The rule, identified as R1007, checks for outgoing TCP connections to commonly used crypto miners ports. Currently, it only checks for the Monero (XMR) - Stratum mining protocol (TCP) on port 3333. The rule is added to the list of rule descriptors and is also included in the test suite. The rule is also added to the runtime-rule-binding.crd.yaml and README.md files for documentation purposes. The rule is also included in the rulebindingsfiles for testing.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `pkg/engine/rule/r1007_crypto_miners.go`: This file contains the implementation of the new rule R1007 for detecting Crypto Miners. The rule checks for outgoing TCP connections to commonly used crypto miners ports.
- `pkg/engine/rule/r1007_crypto_miners_test.go`: This file contains the tests for the new rule R1007. The tests check the rule's response to network events with different destination ports.
- `chart/kubecop/crds/runtime-rule-binding.crd.yaml`: This file has been updated to include the new rule R1007 in the enumeration of rules.
- `pkg/engine/rule/README.md`: The README file has been updated to include a description of the new rule R1007.
- `pkg/rulebindingstore/testdata/rulebindingsfiles/*.yaml`: All rulebindingfiles have been updated to include the new rule R1007 for testing purposes.
</details>
