### PR TITLE
Fixing logs

### DIFF
--- a/pkg/exporters/stdout_exporter.go
+++ b/pkg/exporters/stdout_exporter.go
@@ -28,5 +28,5 @@ func InitStdoutExporter(useStdout *bool) *StdoutExporter {
 func (exporter *StdoutExporter) SendAlert(failedRule rule.RuleFailure) {
 
 	exporter.logger.Error(failedRule.Name(), slog.Int("severity", failedRule.Priority()),
-		slog.String("message", failedRule.Error()), slog.Any("event", failedRule.Event))
+		slog.String("message", failedRule.Error()), slog.Any("event", failedRule.Event()))
 }


### PR DESCRIPTION
## Type
Bug fix

___
## Description
This PR addresses a bug in the logging functionality of the Stdout Exporter. The main change is in the method that sends alerts, where the event is now correctly logged as a function call.

___
## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>stdout_exporter.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/exporters/stdout_exporter.go<br><br>
        <strong>The 'SendAlert' method of the 'StdoutExporter' class has <br>been updated. The 'event' is now correctly logged as a <br>function call instead of a property.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/97/files#diff-720fbdf92dc87851c73298130b8a4ee2991b0e58e6498fddfe1e5bf74900c66e"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>