### PR TITLE
Removing unshare syscall usage from default rule bindings

### DIFF
--- a/chart/kubecop/templates/default-rule-binding.yaml
+++ b/chart/kubecop/templates/default-rule-binding.yaml
@@ -35,7 +35,6 @@ spec:
     - ruleName: "Kernel Module Load"
     - ruleName: "Exec Binary Not In Base Image"
     - ruleName: "Malicious SSH Connection"
-    - ruleName: "Unshare System Call usage"
     - ruleName: "Crypto Miners port detected"
     - ruleName: "Exec from mount"
 

--- a/system-tests/all_alerts_from_malicious_app.py
+++ b/system-tests/all_alerts_from_malicious_app.py
@@ -39,7 +39,6 @@ def all_alerts_from_malicious_app(test_framework):
             "Exec Binary Not In Base Image",
             "Malicious SSH Connection",
             "Exec from mount",
-            "Unshare System Call usage",
             "Crypto Miners port detected"
         ]
 


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR focuses on enhancing the security by removing the unshare syscall usage from the default rule bindings.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>No specific file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        No specific file<br><br>
        <strong>The PR does not provide a specific file but it is clear that <br>the unshare syscall usage has been removed from the default <br>rule bindings.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/109/files#diff-ca3b2cc317848c845a785264b8c15356a0bed5998dcf0524fd8d6d3381434f1b"> </a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>