### PR TITLE
Fixing message id and test

### DIFF
--- a/pkg/exporters/syslog_exporter.go
+++ b/pkg/exporters/syslog_exporter.go
@@ -52,7 +52,7 @@ func (se *SyslogExporter) SendAlert(failedRule rule.RuleFailure) {
 		ProcessID: fmt.Sprintf("%d", failedRule.Event().Pid),
 		StructuredData: []rfc5424.StructuredData{
 			{
-				ID: "kubecop - General Event",
+				ID: fmt.Sprintf("kubecop@%d", failedRule.Event().Pid),
 				Parameters: []rfc5424.SDParam{
 					{
 						Name:  "rule",

--- a/pkg/exporters/syslog_exporter_test.go
+++ b/pkg/exporters/syslog_exporter_test.go
@@ -19,7 +19,7 @@ func setupServer() *syslog.Server {
 	server := syslog.NewServer()
 	server.SetFormat(syslog.Automatic)
 	server.SetHandler(handler)
-	if err := server.ListenUDP("0.0.0.0:514"); err != nil {
+	if err := server.ListenUDP("0.0.0.0:40000"); err != nil { // Due to permission issues, we can't listen on port 514 on the CI.
 		log.Printf("failed to listen on UDP: %v", err)
 		os.Exit(1)
 	}
@@ -52,7 +52,7 @@ func TestSyslogExporter(t *testing.T) {
 	defer server.Kill()
 
 	// Set up environment variables for the exporter
-	syslogHost := "127.0.0.1:514"
+	syslogHost := "127.0.0.1:40000"
 	os.Setenv("SYSLOG_HOST", syslogHost)
 	os.Setenv("SYSLOG_PROTOCOL", "udp")
 

--- a/pkg/exporters/syslog_exporter_test.go
+++ b/pkg/exporters/syslog_exporter_test.go
@@ -20,13 +20,11 @@ func setupServer() *syslog.Server {
 	server.SetFormat(syslog.Automatic)
 	server.SetHandler(handler)
 	if err := server.ListenUDP("0.0.0.0:40000"); err != nil { // Due to permission issues, we can't listen on port 514 on the CI.
-		log.Printf("failed to listen on UDP: %v", err)
-		os.Exit(1)
+		log.Fatalf("failed to listen on UDP: %v", err)
 	}
 
 	if err := server.Boot(); err != nil {
-		log.Printf("failed to boot the server: %v", err)
-		os.Exit(1)
+		log.Fatalf("failed to boot the server: %v", err)
 	}
 
 	go func(channel syslog.LogPartsChannel) {


### PR DESCRIPTION
## Type
bug_fix, enhancement


___

## Description
This PR includes changes to the Syslog Exporter and its corresponding test. The main changes include:
- The ID in the SyslogExporter's SendAlert function is now dynamically generated using the process ID (Pid) from the failed rule event.
- Error handling has been added to the setupServer function in the Syslog Exporter test. If the server fails to listen on UDP or boot, an error message is logged and the program exits.
- The SyslogExporter test now uses the IP address '127.0.0.1' instead of 'localhost'.
- An additional SendAlert call has been added to the SyslogExporter test.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>syslog_exporter.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/exporters/syslog_exporter.go<br><br>
        <strong>The ID in the SendAlert function has been changed to be <br>dynamically generated using the process ID (Pid) from the <br>failed rule event.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/112/files#diff-d84d67a80745d135f3f4af7c387c52361f506fc84f626e517ea8b37b150f8bb7"> +1/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>syslog_exporter_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/exporters/syslog_exporter_test.go<br><br>
        <strong>Error handling has been added to the setupServer function. <br>The test now uses the IP address '127.0.0.1' instead of <br>'localhost'. An additional SendAlert call has been added to <br>the test.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/112/files#diff-2d0498f3e78cc41bc88e067916574580d2468576d542a8a3c156adc98541f387"> +18/-6</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>