### PR TITLE
Adding fields

### DIFF
--- a/pkg/exporters/csv_exporter.go
+++ b/pkg/exporters/csv_exporter.go
@@ -45,6 +45,8 @@ func (ce *CsvExporter) SendAlert(failedRule rule.RuleFailure) {
 	defer csvWriter.Flush()
 	csvWriter.Write([]string{
 		failedRule.Name(),
+		failedRule.Error(),
+		failedRule.FixSuggestion(),
 		failedRule.Event().PodName,
 		failedRule.Event().ContainerName,
 		failedRule.Event().Namespace,
@@ -72,6 +74,8 @@ func writeHeaders(csvPath string) {
 	defer csvWriter.Flush()
 	csvWriter.Write([]string{
 		"Rule Name",
+		"Alert Message",
+		"Fix Suggestion",
 		"Pod Name",
 		"Container Name",
 		"Namespace",


### PR DESCRIPTION
## Type
bug_fix


___

## Description
- The PR introduces two new fields, `Error` and `FixSuggestion`, to the CSV export of the alerts. 
- These fields are added in the `SendAlert` function, which writes the alert data to the CSV file, and in the `writeHeaders` function, which writes the CSV file headers.
- The `Error` field contains the error message of the failed rule, and the `FixSuggestion` field contains suggestions for fixing the failed rule.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>csv_exporter.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/exporters/csv_exporter.go<br><br>

**Two new fields, `Error` and `FixSuggestion`, have been added <br>to the CSV export of the alerts. These fields are added both <br>in the `SendAlert` function and in the `writeHeaders` <br>function.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/117/files#diff-0a2d375b8879952f2c2f2dbfe3d1976f1b38645d958ad75633a9aca5d151aef3"> +4/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>