### PR TITLE
Adding dockerfile and malware database filter

### DIFF
--- a/resources/clamav/Dockerfile
+++ b/resources/clamav/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:23.10 as builder
+ARG SOCKS_PROXY
+ENV SOCKS_PROXY=$SOCKS_PROXY
+RUN apt-get update && apt-get install -y clamav wget curl
+COPY create-filtered-clam-db.sh /
+RUN /create-filtered-clam-db.sh
+
+
+FROM clamav/clamav:1.2.1-24_base
+COPY init.sh /init
+RUN mkdir -p /var/lib/clamav || true
+COPY --from=builder main.cud /var/lib/clamav/main.cud
+RUN chmod +x /init && chown clamav:clamav /var/lib/clamav
+ENV CLAMAV_NO_FRESHCLAMD=true

--- a/resources/clamav/create-filtered-clam-db.sh
+++ b/resources/clamav/create-filtered-clam-db.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -x
+
+# Create a temporary directory:
+mkdir -p tmp
+
+# Get into it
+pushd tmp
+
+# Download the main.cvd file
+if [ -z "$SOCKS_PROXY" ]
+then
+    curl -o main.cvd -L -f http://database.clamav.net/main.cvd
+else
+    curl --socks5-hostname $SOCKS_PROXY -o main.cvd -L -f http://database.clamav.net/main.cvd
+fi
+return_code=$?
+if [ $return_code -ne 0 ]
+then
+    echo "Failed to download main.cvd (http code: $return_code)"
+    exit 1
+fi
+
+# unpack the main.cvd
+sigtool --unpack main.cvd
+if [ $? -ne 0 ]
+then
+    echo "Failed to unpack main.cvd"
+    exit 1
+fi
+rm main.cvd
+
+# Loop over all the files in the tmp directory
+for file in *
+do
+    # If the file has one line, skip
+    if [ $(wc -l < $file) -eq 1 ]
+    then
+        echo "Skipping $file"
+        continue
+    fi
+
+    # If the file is the COPYING or main.cvd file, skip
+    if [ $(basename $file) == "main.cvd" ]
+    then
+        echo "Skipping $file"
+        continue
+    fi
+    if [ $(basename $file) == "COPYING" ]
+    then
+        echo "Skipping $file"
+        continue
+    fi
+
+    # Filter out the lines that does not contain the word "Unix" or "Multios"
+    grep "Unix" $file > $file.tmp
+    grep "Multios" $file >> $file.tmp
+    mv $file.tmp $file
+    # If the file is empty, delete it
+    if [ $(wc -l < $file) -eq 0 ]
+    then
+        echo "Deleting $file"
+        rm $file
+    fi
+done
+
+
+sigtool --version
+printf "slashben\n" | sigtool --build=main.cud --unsigned
+if [ $? -ne 0 ]
+then
+    echo "Failed to build main.cud"
+    exit 1
+fi
+
+
+# Get back
+popd
+
+cp tmp/main.cud main.cud
+
+# Clean up
+rm -rf tmp

--- a/resources/clamav/init.sh
+++ b/resources/clamav/init.sh
@@ -1,0 +1,89 @@
+#!/sbin/tini /bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2021 Olliver Schinagl <oliver@schinagl.nl>
+# Copyright (C) 2021-2023 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+if [ ! -d "/run/clamav" ]; then
+	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+fi
+
+# Assign ownership to the database directory, just in case it is a mounted volume
+chown -R clamav:clamav /var/lib/clamav
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -gt 0 ] && \
+   [ "${1#-}" = "${1}" ] && \
+   command -v "${1}" > "/dev/null" 2>&1; then
+	# Ensure healthcheck always passes
+	CLAMAV_NO_CLAMD="true" exec "${@}"
+else
+	if [ "${#}" -ge 1 ] && \
+	   [ "${1#-}" != "${1}" ]; then
+		# If an argument starts with "-" pass it to clamd specifically
+		exec clamd "${@}"
+	fi
+	# else default to running clamav's servers
+
+	# Help tiny-init a little
+	mkdir -p "/run/lock"
+	ln -f -s "/run/lock" "/var/lock"
+
+	# Ensure we have some virus data, otherwise clamd refuses to start
+    if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then
+        if [ ! -f "/var/lib/clamav/main.cvd" ]; then
+            echo "Updating initial database"
+            freshclam --foreground --stdout
+        fi
+    fi
+
+    # Start freshclamd if not disabled
+	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then
+		echo "Starting Freshclamd"
+		freshclam \
+		          --checks="${FRESHCLAM_CHECKS:-1}" \
+		          --daemon \
+		          --foreground \
+		          --stdout \
+		          --user="clamav" \
+			  &
+	fi
+
+	if [ "${CLAMAV_NO_CLAMD:-false}" != "true" ]; then
+		echo "Starting ClamAV"
+		if [ -S "/run/clamav/clamd.sock" ]; then
+			unlink "/run/clamav/clamd.sock"
+		fi
+		if [ -S "/tmp/clamd.sock" ]; then
+			unlink "/tmp/clamd.sock"
+		fi
+		clamd --foreground &
+		while [ ! -S "/run/clamav/clamd.sock" ] && [ ! -S "/tmp/clamd.sock" ]; do
+			if [ "${_timeout:=0}" -gt "${CLAMD_STARTUP_TIMEOUT:=1800}" ]; then
+				echo
+				echo "Failed to start clamd"
+				exit 1
+			fi
+			printf "\r%s" "Socket for clamd not found yet, retrying (${_timeout}/${CLAMD_STARTUP_TIMEOUT}) ..."
+			sleep 1
+			_timeout="$((_timeout + 1))"
+		done
+		echo "socket found, clamd started."
+	fi
+
+	if [ "${CLAMAV_NO_MILTERD:-true}" != "true" ]; then
+		echo "Starting clamav milterd"
+		clamav-milter &
+	fi
+
+	# Wait forever (or until canceled)
+	exec tail -f "/dev/null"
+fi
+
+exit 0


### PR DESCRIPTION
## Type
enhancement


___

## Description
This PR introduces scripts and a Dockerfile for setting up a ClamAV service with a filtered database. The main changes include:
- A script to create a filtered ClamAV database, which only includes lines containing the words "Unix" or "Multios".
- A script to initialize the ClamAV service, which sets up necessary directories and permissions, checks for the existence of the main.cvd file, updates the database if necessary, and starts the ClamAV services.
- A Dockerfile that uses ubuntu:23.10 as a builder to create the filtered ClamAV database, and then copies the database into a clamav/clamav:1.2.1-24_base image. The Dockerfile also sets the environment variable CLAMAV_NO_FRESHCLAMD to true to disable freshclam.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>create-filtered-clam-db.sh&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        resources/clamav/create-filtered-clam-db.sh<br><br>

**A new shell script file has been added. This script is <br>responsible for creating a filtered ClamAV database. It <br>downloads the main.cvd file, unpacks it, filters out lines <br>that do not contain the word "Unix" or "Multios", and builds <br>the main.cud file.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/121/files#diff-c0a70689fdc8f4fc00a58370c3bea8952b7876cfece5cde4096baccb28b8cffb"> +83/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>init.sh&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        resources/clamav/init.sh<br><br>

**A new shell script file has been added. This script is <br>responsible for initializing the ClamAV service. It sets up <br>necessary directories and permissions, checks for the <br>existence of the main.cvd file, updates the database if <br>necessary, and starts the ClamAV services.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/121/files#diff-308c7bc6741a872211bc72686042122fc7b050fcbfc42ad35e516029d9e01df4"> +89/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        resources/clamav/Dockerfile<br><br>

**A new Dockerfile has been added. It uses ubuntu:23.10 as a <br>builder to create a filtered ClamAV database, and then <br>copies the database into a clamav/clamav:1.2.1-24_base <br>image. It also sets the environment variable <br>CLAMAV_NO_FRESHCLAMD to true.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/121/files#diff-fda09fa8332acc8e61f4bba2dd7c76fc4b75cf604238f685f5187ff276e9bffc"> +14/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>