### PR TITLE
Bugfix/clamav

### DIFF
--- a/chart/kubecop/files/clamd.conf
+++ b/chart/kubecop/files/clamd.conf
@@ -3,6 +3,9 @@ Debug no
 LeaveTemporaryFiles no
 LogTime yes
 LogClean yes
+LocalSocket /run/clamav/clamd.sock
+LocalSocketGroup clamav
+LocalSocketMode 660
 TCPSocket 3310
 TCPAddr 127.0.0.1
 ExcludePath ^/proc/

--- a/chart/kubecop/files/clamd.conf
+++ b/chart/kubecop/files/clamd.conf
@@ -11,5 +11,5 @@ ExcludePath ^/host/proc/
 ExcludePath ^/host/sys/
 ExcludePath ^/host/dev/
 ExcludePath ^/host/run/
-MaxDirectoryRecursion 64
+MaxDirectoryRecursion 20
 ExtendedDetectionInfo yes

--- a/chart/kubecop/templates/deamonset.yaml
+++ b/chart/kubecop/templates/deamonset.yaml
@@ -132,9 +132,12 @@ spec:
       - name: clamd
         image: {{ .Values.clamAV.image.repository }}:{{ .Values.clamAV.image.tag }}
         imagePullPolicy: {{ .Values.clamAV.image.pullPolicy }}
-        redinessProbe:
-          tcpSocket:
-            port: 3310
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "echo 'PING' | nc -w 1 localhost 3310 | grep PONG || exit 1"
           initialDelaySeconds: 50
           periodSeconds: 10
         {{- if .Values.clamAV.resources }}

--- a/chart/kubecop/templates/deamonset.yaml
+++ b/chart/kubecop/templates/deamonset.yaml
@@ -132,13 +132,15 @@ spec:
       - name: clamd
         image: {{ .Values.clamAV.image.repository }}:{{ .Values.clamAV.image.tag }}
         imagePullPolicy: {{ .Values.clamAV.image.pullPolicy }}
+        redinessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 50
+          periodSeconds: 10
+        {{- if .Values.clamAV.resources }}
         resources:
-          requests:
-            memory: "64Mi"
-            cpu: "100m"
-          limits:
-            memory: "350Mi"
-            cpu: "200m"
+          {{- toYaml .Values.clamAV.resources | nindent 12 }}
+        {{- end }}
         volumeMounts:
         - name: clamdb
           mountPath: /var/lib/clamav-tmp # This is a temporary filler until we have a mirror of the clamav database.

--- a/chart/kubecop/values.yaml
+++ b/chart/kubecop/values.yaml
@@ -41,11 +41,18 @@ clamAV:
   host: "localhost"
   port: "3310"
   path: "/host"
-  scanInterval: 600s # Scan interval in seconds.
+  scanInterval: 1h
   image:
     repository: quay.io/armosec/klamav
     pullPolicy: Always
     tag: "beta4"
+  resources:
+    limits:
+      cpu: 300m
+      memory: 400Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/chart/kubecop/values.yaml
+++ b/chart/kubecop/values.yaml
@@ -45,7 +45,7 @@ clamAV:
   image:
     repository: quay.io/armosec/klamav
     pullPolicy: Always
-    tag: "beta4"
+    tag: "beta5"
   resources:
     limits:
       cpu: 300m

--- a/dev/devpod-clamav.yaml
+++ b/dev/devpod-clamav.yaml
@@ -32,8 +32,11 @@ data:
     Foreground yes
     Debug no
     LeaveTemporaryFiles no
-    LogTime yes
+    LogTime no
     LogClean yes
+    LocalSocket /run/clamav/clamd.sock
+    LocalSocketGroup clamav
+    LocalSocketMode 660
     TCPSocket 3310
     TCPAddr 127.0.0.1
     ExcludePath ^/proc/
@@ -42,9 +45,8 @@ data:
     ExcludePath ^/host/sys/
     ExcludePath ^/host/dev/
     ExcludePath ^/host/run/
-    MaxDirectoryRecursion 64
+    MaxDirectoryRecursion 20
     ExtendedDetectionInfo yes
-    ExitOnOOM yes
     VirusEvent "echo VIRUS DETECTED: %v in the path %f >> /dev/stdout"
 
   freshclam.conf: |
@@ -132,7 +134,7 @@ spec:
         - name: bpffs
           mountPath: /sys/fs/bpf
       - name: clamd
-        image: quay.io/armosec/klamav:beta1
+        image: quay.io/armosec/klamav:beta4
         imagePullPolicy: Always
         resources:
           requests:

--- a/pkg/scan/clamav/config.go
+++ b/pkg/scan/clamav/config.go
@@ -1,11 +1,16 @@
 package clamav
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type ClamAVConfig struct {
 	Host         string
 	Port         string
 	ScanInterval string
+	RetryDelay   time.Duration
+	MaxRetries   int
 }
 
 func (c *ClamAVConfig) Address() string {

--- a/resources/clamav/Dockerfile
+++ b/resources/clamav/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:23.10 as builder
 ARG SOCKS_PROXY
 ENV SOCKS_PROXY=$SOCKS_PROXY
-RUN apt-get update && apt-get install -y clamav wget curl netcat
+RUN apt-get update && apt-get install -y clamav wget curl
 COPY create-filtered-clam-db.sh main.cvd /
 RUN /create-filtered-clam-db.sh
 
 
 FROM clamav/clamav-debian:1.2.0-6_base
+RUN apt-get update && apt-get install -y netcat
 COPY init.sh /init
 RUN mkdir -p /var/lib/clamav || true
 COPY --from=builder main.cud /var/lib/clamav/main.cud

--- a/resources/clamav/Dockerfile
+++ b/resources/clamav/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:23.10 as builder
 ARG SOCKS_PROXY
 ENV SOCKS_PROXY=$SOCKS_PROXY
-RUN apt-get update && apt-get install -y clamav wget curl
+RUN apt-get update && apt-get install -y clamav wget curl netcat
 COPY create-filtered-clam-db.sh main.cvd /
 RUN /create-filtered-clam-db.sh
 


### PR DESCRIPTION
## Type
Bug fix, Enhancement


___

## Description
This PR introduces several enhancements and bug fixes related to ClamAV:
- Added a retry mechanism for ClamAV connection and scan. This includes the introduction of two new variables `ClamAVRetryDelay` and `ClamAVMaxRetries` for configuring the retry mechanism.
- Added a mutex for scans to ensure thread safety.
- Updated the `scan` function to return an error instead of terminating the program on failure.
- Updated various ClamAV configurations in the clamd.conf files.
- Added a liveness probe for the clamd container in the Kubernetes DaemonSet.
- Updated resource limits and requests for the ClamAV container in the Kubernetes DaemonSet.
- Added netcat to the ClamAV Docker image.


___

## Changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        cmd/main.go<br><br>

**Added retry mechanism for ClamAV connection and scan. <br>Introduced two new variables `ClamAVRetryDelay` and <br>`ClamAVMaxRetries` for configuring the retry mechanism. <br>Also, the connection retry logic has been updated to use <br>these new variables.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/134/files#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6"> +19/-13</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clamav.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/scan/clamav/clamav.go<br><br>

**Added a mutex for scans and a retry mechanism for scans. The <br>`ClamAV` struct now includes a mutex, retry delay, and max <br>retries. The `scan` function now returns an error instead of <br>terminating the program on failure. A new function <br>`scanWithRetries` has been added to handle retries on scan <br>failure.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/134/files#diff-ff73bd401013d0c9790bcb3e68c18084bb00c65133657e5471acdad8b2001d43"> +43/-8</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/scan/clamav/config.go<br><br>

**Added `RetryDelay` and `MaxRetries` to the `ClamAVConfig` <br>struct.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/134/files#diff-f31996d20e15fd15a4cb1a6fa43a9492d85c214d6666e8f088f98e3a1509fca2"> +6/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clamd.conf&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        chart/kubecop/files/clamd.conf<br><br>

**Added LocalSocket, LocalSocketGroup, and LocalSocketMode <br>configurations. Reduced MaxDirectoryRecursion from 64 to <br>20.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/134/files#diff-9d0902593972389759369b8086615d2b119ef51971b3f42d567312f852cab106"> +4/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deamonset.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        chart/kubecop/templates/deamonset.yaml<br><br>

**Added a liveness probe for the clamd container. Updated the <br>resources configuration to use values from the values.yaml <br>file.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/134/files#diff-85e96503359a8117f75f7b5e72b88e65cad1abdd451b7ea40e1c199289434d39"> +11/-6</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        chart/kubecop/values.yaml<br><br>

**Updated ClamAV configuration values. The scanInterval has <br>been changed from 600s to 1h. The image tag has been updated <br>from beta4 to beta5. Added resource limits and requests for <br>the ClamAV container.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/134/files#diff-a76a9e679fe402f7217b3d2cef96f308de47dc05a8d4cd9b8920a9bf051e0180"> +9/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>devpod-clamav.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        dev/devpod-clamav.yaml<br><br>

**Updated clamd.conf configuration. LogTime has been set to <br>no. LocalSocket, LocalSocketGroup, and LocalSocketMode <br>configurations have been added. MaxDirectoryRecursion has <br>been reduced from 64 to 20. The ExitOnOOM configuration has <br>been removed. The image tag for the clamd container has been <br>updated from beta1 to beta4.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/134/files#diff-cc130b49854030530dc8584fbf2f2ca4488182c9c5abaf657b8554e077cbd834"> +6/-4</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        resources/clamav/Dockerfile<br><br>

**Added netcat to the clamav/clamav-debian:1.2.0-6_base <br>image.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/134/files#diff-fda09fa8332acc8e61f4bba2dd7c76fc4b75cf604238f685f5187ff276e9bffc"> +1/-0</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>