### PR TITLE
Fixing missing netcat in image

### DIFF
--- a/resources/clamav/Dockerfile
+++ b/resources/clamav/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:23.10 as builder
 ARG SOCKS_PROXY
 ENV SOCKS_PROXY=$SOCKS_PROXY
-RUN apt-get update && apt-get install -y clamav wget curl netcat
+RUN apt-get update && apt-get install -y clamav wget curl
 COPY create-filtered-clam-db.sh main.cvd /
 RUN /create-filtered-clam-db.sh
 
 
 FROM clamav/clamav-debian:1.2.0-6_base
+RUN apt-get update && apt-get install -y netcat
 COPY init.sh /init
 RUN mkdir -p /var/lib/clamav || true
 COPY --from=builder main.cud /var/lib/clamav/main.cud


### PR DESCRIPTION
## Type
Bug fix


___

## Description
This PR addresses a bug in the Dockerfile for the ClamAV image. The main changes include:
- The installation of `netcat` was initially done in the `ubuntu` image, which was not persisted to the final `clamav/clamav-debian` image.
- To fix this, the `netcat` installation command has been moved to the `clamav/clamav-debian` image, ensuring that `netcat` is available in the final image.


___

## Changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        resources/clamav/Dockerfile<br><br>

**The installation of `netcat` has been moved from the initial <br>`ubuntu` image to the final `clamav/clamav-debian` image in <br>the Dockerfile.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/135/files#diff-fda09fa8332acc8e61f4bba2dd7c76fc4b75cf604238f685f5187ff276e9bffc"> +2/-1</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>