### PR TITLE
Adding Gomemlimit to fix slow memory leak

### DIFF
--- a/chart/kubecop/templates/deamonset.yaml
+++ b/chart/kubecop/templates/deamonset.yaml
@@ -50,8 +50,12 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.kubecop.resources | nindent 12 }}
         env:
+          {{- if .Values.kubecop.gomemlimit.enabled }}
+          - name: GOMEMLIMIT
+            value: "{{ .Values.kubecop.gomemlimit.limit }}"
+          {{- end }}
           - name: NODE_NAME
             valueFrom:
               fieldRef:

--- a/chart/kubecop/values.yaml
+++ b/chart/kubecop/values.yaml
@@ -12,6 +12,17 @@ nameOverride: ""
 fullnameOverride: "kubecop"
 
 kubecop:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  gomemlimit:
+    enabled: true
+    # It is recommended to set this value to 3/4 of the memory limit
+    limit: 384Mi
   recording:
     samplingInterval: 60s
     finalizationDuration: 900s
@@ -49,7 +60,7 @@ clamAV:
   resources:
     limits:
       cpu: 300m
-      memory: 400Mi
+      memory: 512Mi
     requests:
       cpu: 100m
       memory: 256Mi
@@ -76,13 +87,7 @@ securityContext:
 
 securityContextNormal: {}
 
-resources:
-  limits:
-    cpu: 500m
-    memory: 1Gi
-  requests:
-    cpu: 100m
-    memory: 256Mi
+
 
 
 nodeSelector: {}


### PR DESCRIPTION
## Type
Enhancement


___

## Description
- This PR introduces a new configuration `gomemlimit` under `kubecop` in `values.yaml`. This includes an `enabled` field to toggle the feature and a `limit` field to set the memory limit.
- The `resources` configuration has been moved from the global scope to under `kubecop` in `values.yaml`.
- The `resources` configuration for `clamAV` has been updated.
- In `deamonset.yaml`, the resources reference has been updated to point to the new location under `kubecop`.
- An environment variable `GOMEMLIMIT` has been added to `deamonset.yaml`, which is set if `gomemlimit` is enabled.


___

## Changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deamonset.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        chart/kubecop/templates/deamonset.yaml<br><br>

**- Changed the resources reference from `.Values.resources` <br>to `.Values.kubecop.resources`.
- Added a conditional <br>environment variable `GOMEMLIMIT` which is set if <br>`.Values.kubecop.gomemlimit.enabled` is true.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/136/files#diff-85e96503359a8117f75f7b5e72b88e65cad1abdd451b7ea40e1c199289434d39"> +5/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        chart/kubecop/values.yaml<br><br>

**- Added `resources` and `gomemlimit` configuration under <br>`kubecop`.
- `gomemlimit` includes `enabled` and `limit` <br>fields.
- Updated the `resources` configuration for <br>`clamAV`.
- Removed the global `resources` configuration.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/136/files#diff-a76a9e679fe402f7217b3d2cef96f308de47dc05a8d4cd9b8920a9bf051e0180"> +13/-8</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>