### PR TITLE
Limiting KubeCop RBAC

### DIFF
--- a/chart/kubecop/templates/clusterrole.yaml
+++ b/chart/kubecop/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
   verbs: ["get"]
 - apiGroups: ["kubescape.io"]
   resources: ["applicationprofiles", "namespaces/*/*", "namespaces/*/applicationprofiles/*"]
-  verbs: ["watch", "create", "update", "get"]
+  verbs: ["watch", "create", "update", "get", "list", "delete", "patch"]
 - apiGroups: ["kubescape.io"]
   resources: ["runtimerulealertbindings"]
   verbs: ["list", "watch"]

--- a/chart/kubecop/templates/clusterrole.yaml
+++ b/chart/kubecop/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "..fullname" . }}
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "pods", "serviceaccounts"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["apps","batch","extensions"]
+  resources: ["*"]
+  verbs: ["get"]
+- apiGroups: ["kubescape.io"]
+  resources: ["applicationprofiles", "namespaces/*/*", "namespaces/*/applicationprofiles/*"]
+  verbs: ["watch", "create", "update", "get"]
+- apiGroups: ["kubescape.io"]
+  resources: ["runtimerulealertbindings"]
+  verbs: ["list", "watch"]

--- a/chart/kubecop/templates/clusterrolebinding.yaml
+++ b/chart/kubecop/templates/clusterrolebinding.yaml
@@ -8,5 +8,5 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ include "..fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/chart/kubecop/templates/controller-statefulset.yaml
+++ b/chart/kubecop/templates/controller-statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContextNormal | nindent 12 }}
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.kubecop.resources | nindent 12 }}
         env:
           {{- if .Values.isNamespaced }}
           - name: STORE_NAMESPACE

--- a/chart/kubecop/values.yaml
+++ b/chart/kubecop/values.yaml
@@ -87,9 +87,6 @@ securityContext:
 
 securityContextNormal: {}
 
-
-
-
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## **User description**
Created a ClusterRole that KubeCop uses and tailored to the Kubernetes API usage of KubeCop (previous used `cluster-admin`)


___

## **Type**
enhancement


___

## **Description**
- Introduced a new ClusterRole specifically tailored for KubeCop, significantly reducing the permissions from the previous `cluster-admin` role.
- Updated the ClusterRoleBinding to reference the new ClusterRole, aligning with the principle of least privilege.
- Adjusted the StatefulSet configuration to refine resource allocation for KubeCop.
- Cleaned up the `values.yaml` file by removing unnecessary newline characters.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusterrole.yaml</strong><dd><code>Introduce Tailored ClusterRole for KubeCop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chart/kubecop/templates/clusterrole.yaml
<li>Created a new ClusterRole with specific permissions tailored to <br>KubeCop's needs.<br> <li> Defined permissions for <code>namespaces</code>, <code>pods</code>, <code>serviceaccounts</code>, and various <br>resources under <code>apps</code>, <code>batch</code>, <code>extensions</code>, and <code>kubescape.io</code> apiGroups.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/166/files#diff-6b450e258c95f485694cee71780129567de137ab192b0f97a0b9723b911bad39">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clusterrolebinding.yaml</strong><dd><code>Update ClusterRoleBinding to Use New ClusterRole</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chart/kubecop/templates/clusterrolebinding.yaml
<li>Modified the ClusterRoleBinding to reference the newly created <br>ClusterRole instead of <code>cluster-admin</code>.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/166/files#diff-2b40f42238d7ff561092fbafa4418164b1cce093a7d12e3c1839b8e18032da7c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>controller-statefulset.yaml</strong><dd><code>Refine Resource Allocation in StatefulSet Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chart/kubecop/templates/controller-statefulset.yaml
<li>Adjusted resource allocation settings to use <code>kubecop.resources</code> instead <br>of <code>.Values.resources</code>.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/166/files#diff-94879afdd23579720c115da5b7271da861315680ff43c4546e9ef87b19e35c9b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Cleanup Newline Characters in Values File</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chart/kubecop/values.yaml
- Removed extraneous newline characters.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/166/files#diff-a76a9e679fe402f7217b3d2cef96f308de47dc05a8d4cd9b8920a9bf051e0180">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
