### PR TITLE
add-http-exporter + UTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ helm install kubecop kubecop/kubecop -n kubescape --create-namespace --set isNam
 ```
 
 #### Advanced parameter configurations
+Exporters are the mechanisms in the system to send alerts to external endpoints from KubeCop engine.
+For more information about exporters, see [here](/pkg/exporters/README.md)
 
 ##### Finalization
 

--- a/chart/kubecop/Chart.yaml
+++ b/chart/kubecop/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm chart for Kubernetes Runtime Security detection system KubeC
 
 type: application
 
-version: 0.0.36
+version: 0.0.37
 
-appVersion: "0.0.36"
+appVersion: "0.0.37"
 
 
 dependencies:

--- a/chart/kubecop/templates/deamonset.yaml
+++ b/chart/kubecop/templates/deamonset.yaml
@@ -76,6 +76,10 @@ spec:
           - name: ALERTMANAGER_URLS
             value: {{ .Values.kubecop.alertmanager.endpoints }}
           {{- end }}
+          {{- if .Values.kubecop.httpEndpoint.enabled  }}
+          - name: HTTP_ENDPOINT_URL
+            value: {{ .Values.kubecop.httpEndpoint.url }}
+          {{- end }}
           {{- if .Values.kubecop.syslog.enabled  }}
           - name: SYSLOG_HOST
             value: {{ .Values.kubecop.syslog.endpoint }}

--- a/chart/kubecop/values.yaml
+++ b/chart/kubecop/values.yaml
@@ -30,6 +30,9 @@ kubecop:
   alertmanager:
     enabled: false
     endpoints: "localhost:9093"
+  httpEndpoint:
+    enabled: false
+    url: "http://synchronizer.kubescape.svc.cluster.local"
   syslog:
     enabled: false
     endpoint: "localhost:514"

--- a/chart/kubecop/values.yaml
+++ b/chart/kubecop/values.yaml
@@ -5,7 +5,7 @@
 image:
   repository: quay.io/armosec/kubecop
   pullPolicy: Always
-  tag: "v0.0.36"
+  tag: "v0.0.37"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -32,7 +32,7 @@ kubecop:
     endpoints: "localhost:9093"
   httpEndpoint:
     enabled: false
-    url: "http://synchronizer.kubescape.svc.cluster.local"
+    url: "http://synchronizer.kubescape.svc.cluster.local/apis/v1/kubescape.io/v1/RuntimeAlerts"
   syslog:
     enabled: false
     endpoint: "localhost:514"

--- a/pkg/exporters/README.md
+++ b/pkg/exporters/README.md
@@ -7,6 +7,7 @@ The following exporters are available:
 - STD OUT
 - SYSLOG
 - CSV
+- HTTP endpoint
 
 ### Alertmanager
 The Alertmanager exporter is used to send alerts to the Alertmanager. The Alertmanager will then send the alerts to the configured receivers.
@@ -31,3 +32,10 @@ The CSV exporter is used to write the alerts to a CSV file. This exporter is dis
 To enable the CSV exporter, set the following environment variables:
 - `EXPORTER_CSV_RULE_PATH`: The path to the CSV file of the failed rules. Example: `/tmp/alerts.csv`
 - `EXPORTER_CSV_MALWARE_PATH`: The path to the CSV file of the malwares found. Example: `/tmp/malware.csv`
+
+### HTTP endpoint
+The HTTP endpoint exporter is used to send the alerts to an HTTP endpoint. This exporter is disabled by default.
+To enable the HTTP endpoint exporter, set the following environment variables:
+- `HTTP_ENDPOINT_URL`: The URL of the HTTP endpoint. Example: `http://localhost:8080/alerts`
+This will send a POST request to the specified URL with the alerts as the body.
+The alerts are limited to 10000 per minute. If the limit is reached, the exporter will stop sending alerts for the rest of the minute and will send a system alert to the configured HTTP endpoint.

--- a/pkg/exporters/exporters_bus.go
+++ b/pkg/exporters/exporters_bus.go
@@ -54,6 +54,12 @@ func InitExporters(exportersConfig ExportersConfig) ExporterBus {
 	if csvExp != nil {
 		exporters = append(exporters, csvExp)
 	}
+	if exportersConfig.HTTPExporterConfig == nil {
+		if httpURL := os.Getenv("HTTP_ENDPOINT_URL"); httpURL != "" {
+			exportersConfig.HTTPExporterConfig = &HTTPExporterConfig{}
+			exportersConfig.HTTPExporterConfig.URL = httpURL
+		}
+	}
 	if exportersConfig.HTTPExporterConfig != nil {
 		httpExp, err := InitHTTPExporter(*exportersConfig.HTTPExporterConfig)
 		if err != nil {

--- a/pkg/exporters/exporters_bus.go
+++ b/pkg/exporters/exporters_bus.go
@@ -11,11 +11,12 @@ import (
 )
 
 type ExportersConfig struct {
-	StdoutExporter           *bool  `yaml:"stdoutExporter"`
-	AlertManagerExporterUrls string `yaml:"alertManagerExporterUrls"`
-	SyslogExporter           string `yaml:"syslogExporterURL"`
-	CsvRuleExporterPath      string `yaml:"CsvRuleExporterPath"`
-	CsvMalwareExporterPath   string `yaml:"CsvMalwareExporterPath"`
+	StdoutExporter           *bool               `yaml:"stdoutExporter"`
+	AlertManagerExporterUrls string              `yaml:"alertManagerExporterUrls"`
+	SyslogExporter           string              `yaml:"syslogExporterURL"`
+	CsvRuleExporterPath      string              `yaml:"CsvRuleExporterPath"`
+	CsvMalwareExporterPath   string              `yaml:"CsvMalwareExporterPath"`
+	HTTPExporterConfig       *HTTPExporterConfig `yaml:"httpExporterConfig"`
 }
 
 // This file will contain the single point of contact for all exporters,
@@ -26,16 +27,14 @@ const (
 	AlertManagerSepartorDelimiter = ","
 )
 
-var (
+type ExporterBus struct {
 	// Exporters is a list of all exporters.
 	exporters []Exporter
-)
-
-type ExporterBus struct {
 }
 
 // InitExporters initializes all exporters.
 func InitExporters(exportersConfig ExportersConfig) ExporterBus {
+	exporters := []Exporter{}
 	alertManagerUrls := parseAlertManagerUrls(exportersConfig.AlertManagerExporterUrls)
 	for _, url := range alertManagerUrls {
 		alertMan := InitAlertManagerExporter(url)
@@ -55,13 +54,20 @@ func InitExporters(exportersConfig ExportersConfig) ExporterBus {
 	if csvExp != nil {
 		exporters = append(exporters, csvExp)
 	}
+	if exportersConfig.HTTPExporterConfig != nil {
+		httpExp, err := InitHTTPExporter(*exportersConfig.HTTPExporterConfig)
+		if err != nil {
+			log.WithError(err).Error("failed to initialize HTTP exporter")
+		}
+		exporters = append(exporters, httpExp)
+	}
 
 	if len(exporters) == 0 {
 		panic("no exporters were initialized")
 	}
 	log.Info("exporters initialized")
 
-	return ExporterBus{}
+	return ExporterBus{exporters: exporters}
 }
 
 // ParseAlertManagerUrls parses the alert manager urls from the given string.
@@ -79,13 +85,13 @@ func parseAlertManagerUrls(urls string) []string {
 }
 
 func (e *ExporterBus) SendRuleAlert(failedRule rule.RuleFailure) {
-	for _, exporter := range exporters {
+	for _, exporter := range e.exporters {
 		exporter.SendRuleAlert(failedRule)
 	}
 }
 
 func (e *ExporterBus) SendMalwareAlert(malwareDescription scan.MalwareDescription) {
-	for _, exporter := range exporters {
+	for _, exporter := range e.exporters {
 		exporter.SendMalwareAlert(malwareDescription)
 	}
 }

--- a/pkg/exporters/http_exporter.go
+++ b/pkg/exporters/http_exporter.go
@@ -1,0 +1,262 @@
+package exporters
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/armosec/kubecop/pkg/engine/rule"
+	"github.com/armosec/kubecop/pkg/scan"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type HTTPExporterConfig struct {
+	// URL is the URL to send the HTTP POST request to
+	URL string `json:"url"`
+	// Headers is a map of headers to send in the HTTP POST request
+	Headers map[string]string `json:"headers"`
+	// Timeout is the timeout for the HTTP POST request
+	TimeoutSeconds int `json:"timeoutSeconds"`
+	// Method is the HTTP method to use for the HTTP request
+	Method             string `json:"method"`
+	MaxAlertsPerMinute int    `json:"maxAlertsPerMinute"`
+}
+
+// we will have a CRD-like json struct to send in the HTTP POST request
+type HTTPExporter struct {
+	Host       string
+	NodeName   string
+	config     HTTPExporterConfig
+	httpClient *http.Client
+	// alertCount is the number of alerts sent in the last minute, used to limit the number of alerts sent so we don't overload the system or reach the rate limit
+	alertCount      int
+	alertCountLock  sync.Mutex
+	alertCountStart time.Time
+}
+
+type HTTPAlertsList struct {
+	Kind       string             `json:"kind"`
+	ApiVersion string             `json:"apiVersion"`
+	Spec       HTTPAlertsListSpec `json:"items"`
+}
+
+type HTTPAlertsListSpec struct {
+	Alerts []HTTPAlert `json:"alerts"`
+}
+
+type RuleAlert struct {
+	Severity       int    `json:"severity,omitempty"`    // PriorityToStatus(failedRule.Priority()),
+	CommandName    string `json:"commandName,omitempty"` // failedRule.Event().Comm,
+	FixSuggestions string `json:"fixSuggestions,omitempty"`
+	PID            uint32 `json:"pid,omitempty"`
+	PPID           uint32 `json:"ppid,omitempty"` //  Parent Process ID
+	UID            uint32 `json:"uid,omitempty"`  // User ID of the process
+	GID            uint32 `json:"gid,omitempty"`  // Group ID of the process
+}
+
+type MalwareAlert struct {
+	MalwareName        string `json:"malwareName,omitempty"`
+	MalwareDescription string `json:"malwareDescription,omitempty"`
+	// Path to the file that was infected
+	Path string `json:"path,omitempty"`
+	// Hash of the file that was infected
+	Hash string `json:"hash,omitempty"`
+	// Size of the file that was infected
+	Size string `json:"size,omitempty"`
+	// Is part of the image
+	IsPartOfImage bool `json:"isPartOfImage,omitempty"`
+	// K8s resource that was infected
+	Resource schema.GroupVersionResource `json:"resource,omitempty"`
+	// K8s container image that was infected
+	ContainerImage string `json:"containerImage,omitempty"`
+}
+
+type HTTPAlert struct {
+	RuleAlert     `json:",inline"`
+	MalwareAlert  `json:",inline"`
+	RuleName      string `json:"ruleName"`
+	Message       string `json:"message"`
+	ContainerID   string `json:"containerID,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+	PodNamespace  string `json:"podNamespace,omitempty"`
+	PodName       string `json:"podName,omitempty"`
+	HostName      string `json:"hostName"`
+	NodeName      string `json:"nodeName"`
+}
+
+func (config *HTTPExporterConfig) Validate() error {
+	if config.Method == "" {
+		config.Method = "POST"
+	} else if config.Method != "POST" && config.Method != "PUT" {
+		return fmt.Errorf("method must be POST or PUT")
+	}
+	if config.TimeoutSeconds == 0 {
+		config.TimeoutSeconds = 1
+	}
+	if config.MaxAlertsPerMinute == 0 {
+		config.MaxAlertsPerMinute = 10000
+	}
+	if config.Headers == nil {
+		config.Headers = make(map[string]string)
+	}
+	if config.URL == "" {
+		return fmt.Errorf("URL is required")
+	}
+	return nil
+}
+
+// InitHTTPExporter initializes an HTTPExporter with the given URL, headers, timeout, and method
+func InitHTTPExporter(config HTTPExporterConfig) (*HTTPExporter, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &HTTPExporter{
+		config: config,
+		httpClient: &http.Client{
+			Timeout: time.Duration(config.TimeoutSeconds) * time.Second,
+		},
+	}, nil
+}
+
+func (exporter *HTTPExporter) sendAlertLimitReached() {
+	httpAlert := HTTPAlert{
+		Message:  "Alert limit reached",
+		RuleName: "AlertLimitReached",
+		HostName: exporter.Host,
+		NodeName: exporter.NodeName,
+		RuleAlert: RuleAlert{
+			Severity:       rule.RulePrioritySystemIssue,
+			FixSuggestions: "Check logs for more information",
+		},
+	}
+	fmt.Fprintf(os.Stderr, "Alert limit reached %d alerts since %s\n", exporter.alertCount, exporter.alertCountStart.Format(time.RFC3339))
+	exporter.sendInAlertList(httpAlert)
+}
+
+func (exporter *HTTPExporter) SendRuleAlert(failedRule rule.RuleFailure) {
+	isLimitReached := exporter.checkAlertLimit()
+	if isLimitReached {
+		exporter.sendAlertLimitReached()
+		return
+	}
+	// populate the HTTPAlert struct with the data from the failedRule
+	httpAlert := HTTPAlert{
+		Message:       failedRule.Error(),
+		RuleName:      failedRule.Name(),
+		ContainerID:   failedRule.Event().ContainerID,
+		ContainerName: failedRule.Event().ContainerName,
+		PodNamespace:  failedRule.Event().Namespace,
+		PodName:       failedRule.Event().PodName,
+		HostName:      exporter.Host,
+		NodeName:      exporter.NodeName,
+		RuleAlert: RuleAlert{
+			Severity:       failedRule.Priority(),
+			FixSuggestions: failedRule.FixSuggestion(),
+			PID:            failedRule.Event().Pid,
+			PPID:           failedRule.Event().Ppid,
+			CommandName:    failedRule.Event().Comm,
+			UID:            failedRule.Event().Uid,
+			GID:            failedRule.Event().Gid,
+		},
+	}
+	exporter.sendInAlertList(httpAlert)
+}
+
+func (exporter *HTTPExporter) sendInAlertList(httpAlert HTTPAlert) {
+	// create the HTTPAlertsListSpec struct
+	// TODO: accumulate alerts and send them in a batch
+	httpAlertsListSpec := HTTPAlertsListSpec{
+		Alerts: []HTTPAlert{httpAlert},
+	}
+	// create the HTTPAlertsList struct
+	httpAlertsList := HTTPAlertsList{
+		Kind:       "RuntimeAlerts",
+		ApiVersion: "kubescape.io/v1",
+		Spec:       httpAlertsListSpec,
+	}
+
+	// create the JSON representation of the HTTPAlertsList struct
+	bodyBytes, err := json.Marshal(httpAlertsList)
+	if err != nil {
+		fmt.Printf("Error marshalling HTTPAlertsList: %v\n", err)
+		return
+	}
+	bodyReader := bytes.NewReader(bodyBytes)
+
+	// send the HTTP request
+	req, err := http.NewRequest(exporter.config.Method, exporter.config.URL, bodyReader)
+	if err != nil {
+		fmt.Printf("Error creating HTTP request: %v\n", err)
+		return
+	}
+	for key, value := range exporter.config.Headers {
+		req.Header.Set(key, value)
+	}
+	resp, err := exporter.httpClient.Do(req)
+	if err != nil {
+		fmt.Printf("Error sending HTTP request: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		fmt.Printf("Received non-2xx status code: %d\n", resp.StatusCode)
+		return
+	}
+
+	// discard the body
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		fmt.Printf("Error clearing response body: %v\n", err)
+	}
+}
+
+func (exporter *HTTPExporter) SendMalwareAlert(malwareDescription scan.MalwareDescription) {
+	isLimitReached := exporter.checkAlertLimit()
+	if isLimitReached {
+		exporter.sendAlertLimitReached()
+		return
+	}
+	httpAlert := HTTPAlert{
+		RuleName:      "KubeCopMalwareDetected",
+		HostName:      exporter.Host,
+		NodeName:      exporter.NodeName,
+		ContainerID:   malwareDescription.ContainerID,
+		ContainerName: malwareDescription.ContainerName,
+		PodNamespace:  malwareDescription.Namespace,
+		PodName:       malwareDescription.PodName,
+		MalwareAlert: MalwareAlert{
+			MalwareName:        malwareDescription.Name,
+			MalwareDescription: malwareDescription.Description,
+			Path:               malwareDescription.Path,
+			Hash:               malwareDescription.Hash,
+			Size:               malwareDescription.Size,
+			IsPartOfImage:      malwareDescription.IsPartOfImage,
+			Resource:           malwareDescription.Resource,
+			ContainerImage:     malwareDescription.ContainerImage,
+		},
+	}
+	exporter.sendInAlertList(httpAlert)
+
+}
+
+func (exporter *HTTPExporter) checkAlertLimit() bool {
+	exporter.alertCountLock.Lock()
+	defer exporter.alertCountLock.Unlock()
+
+	if exporter.alertCountStart.IsZero() {
+		exporter.alertCountStart = time.Now()
+	}
+
+	if time.Since(exporter.alertCountStart) > time.Minute {
+		exporter.alertCountStart = time.Now()
+		exporter.alertCount = 0
+	}
+
+	exporter.alertCount++
+	return exporter.alertCount > exporter.config.MaxAlertsPerMinute
+}

--- a/pkg/exporters/http_exporter.go
+++ b/pkg/exporters/http_exporter.go
@@ -51,7 +51,7 @@ type HTTPAlertsListSpec struct {
 
 type RuleAlert struct {
 	Severity       int    `json:"severity,omitempty"`    // PriorityToStatus(failedRule.Priority()),
-	CommandName    string `json:"commandName,omitempty"` // failedRule.Event().Comm,
+	ProcessName    string `json:"processName,omitempty"` // failedRule.Event().Comm,
 	FixSuggestions string `json:"fixSuggestions,omitempty"`
 	PID            uint32 `json:"pid,omitempty"`
 	PPID           uint32 `json:"ppid,omitempty"` //  Parent Process ID
@@ -160,7 +160,7 @@ func (exporter *HTTPExporter) SendRuleAlert(failedRule rule.RuleFailure) {
 			FixSuggestions: failedRule.FixSuggestion(),
 			PID:            failedRule.Event().Pid,
 			PPID:           failedRule.Event().Ppid,
-			CommandName:    failedRule.Event().Comm,
+			ProcessName:    failedRule.Event().Comm,
 			UID:            failedRule.Event().Uid,
 			GID:            failedRule.Event().Gid,
 		},

--- a/pkg/exporters/http_exporter.go
+++ b/pkg/exporters/http_exporter.go
@@ -42,7 +42,7 @@ type HTTPExporter struct {
 type HTTPAlertsList struct {
 	Kind       string             `json:"kind"`
 	ApiVersion string             `json:"apiVersion"`
-	Spec       HTTPAlertsListSpec `json:"items"`
+	Spec       HTTPAlertsListSpec `json:"spec"`
 }
 
 type HTTPAlertsListSpec struct {

--- a/pkg/exporters/http_exporter.go
+++ b/pkg/exporters/http_exporter.go
@@ -16,18 +16,18 @@ import (
 )
 
 type HTTPExporterConfig struct {
-	// URL is the URL to send the HTTP POST request to
+	// URL is the URL to send the HTTP request to
 	URL string `json:"url"`
-	// Headers is a map of headers to send in the HTTP POST request
+	// Headers is a map of headers to send in the HTTP request
 	Headers map[string]string `json:"headers"`
-	// Timeout is the timeout for the HTTP POST request
+	// Timeout is the timeout for the HTTP request
 	TimeoutSeconds int `json:"timeoutSeconds"`
 	// Method is the HTTP method to use for the HTTP request
 	Method             string `json:"method"`
 	MaxAlertsPerMinute int    `json:"maxAlertsPerMinute"`
 }
 
-// we will have a CRD-like json struct to send in the HTTP POST request
+// we will have a CRD-like json struct to send in the HTTP request
 type HTTPExporter struct {
 	Host       string
 	NodeName   string

--- a/pkg/exporters/http_exporter_test.go
+++ b/pkg/exporters/http_exporter_test.go
@@ -1,0 +1,231 @@
+package exporters
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/armosec/kubecop/pkg/engine/rule"
+	"github.com/armosec/kubecop/pkg/scan"
+	"github.com/kubescape/kapprofiler/pkg/tracing"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestSendRuleAlert(t *testing.T) {
+	bodyChan := make(chan []byte, 1)
+	// Create a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Failed to read request body: %v", err)
+		}
+		bodyChan <- body
+	}))
+	defer server.Close()
+
+	// Create an HTTPExporter with the mock server URL
+	exporter, err := InitHTTPExporter(HTTPExporterConfig{
+		URL: server.URL,
+	})
+	assert.NoError(t, err)
+
+	// Create a mock rule failure
+	failedRule := &rule.R0001UnexpectedProcessLaunchedFailure{
+		RulePriority: rule.RulePriorityCritical,
+		RuleName:     "testrule",
+		Err:          "Application profile is missing",
+		FailureEvent: &tracing.ExecveEvent{GeneralEvent: tracing.GeneralEvent{
+			ContainerName: "testcontainer", ContainerID: "testcontainerid", Namespace: "testnamespace", PodName: "testpodname"}},
+	}
+
+	// Call SendRuleAlert
+	exporter.SendRuleAlert(failedRule)
+
+	// Assert that the HTTP request was sent correctly
+	alertsList := HTTPAlertsList{}
+	select {
+	case body := <-bodyChan:
+		if err := json.Unmarshal(body, &alertsList); err != nil {
+			t.Fatalf("Failed to unmarshal request body: %v", err)
+		}
+
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Timed out waiting for request body")
+	}
+	assert.Equal(t, "RuntimeAlerts", alertsList.Kind)
+	assert.Equal(t, "kubescape.io/v1", alertsList.ApiVersion)
+	assert.Equal(t, 1, len(alertsList.Spec.Alerts))
+	alert := alertsList.Spec.Alerts[0]
+	assert.Equal(t, rule.RulePriorityCritical, alert.Severity)
+	assert.Equal(t, "testrule", alert.RuleName)
+	assert.Equal(t, "testcontainerid", alert.ContainerID)
+	assert.Equal(t, "testcontainer", alert.ContainerName)
+	assert.Equal(t, "testnamespace", alert.PodNamespace)
+	assert.Equal(t, "testpodname", alert.PodName)
+}
+
+func TestSendRuleAlertRateReached(t *testing.T) {
+	bodyChan := make(chan []byte, 1)
+	// Create a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Failed to read request body: %v", err)
+		}
+		bodyChan <- body
+	}))
+	defer server.Close()
+	// Create an HTTPExporter with the mock server URL
+	exporter, err := InitHTTPExporter(HTTPExporterConfig{
+		URL:                server.URL,
+		MaxAlertsPerMinute: 1,
+	})
+	assert.NoError(t, err)
+
+	// Create a mock rule failure
+	failedRule := &rule.R0001UnexpectedProcessLaunchedFailure{
+		RulePriority: rule.RulePriorityCritical,
+		RuleName:     "testrule",
+		Err:          "Application profile is missing",
+		FailureEvent: &tracing.ExecveEvent{GeneralEvent: tracing.GeneralEvent{
+			ContainerName: "testcontainer", ContainerID: "testcontainerid", Namespace: "testnamespace", PodName: "testpodname"}},
+	}
+
+	// Call SendRuleAlert multiple times
+	exporter.SendRuleAlert(failedRule)
+	exporter.SendRuleAlert(failedRule)
+	alertsList := HTTPAlertsList{}
+	select {
+	case body := <-bodyChan:
+		if err := json.Unmarshal(body, &alertsList); err != nil {
+			t.Fatalf("Failed to unmarshal request body: %v", err)
+		}
+
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Timed out waiting for request body")
+	}
+	// Assert that the second request was not sent
+	alertsList = HTTPAlertsList{}
+	select {
+	case body := <-bodyChan:
+		if err := json.Unmarshal(body, &alertsList); err != nil {
+			t.Fatalf("Failed to unmarshal request body: %v", err)
+		}
+
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Timed out waiting for request body")
+	}
+	// Assert that the HTTP request contains the alert limit reached alert
+	alert := alertsList.Spec.Alerts[0]
+	assert.Equal(t, "AlertLimitReached", alert.RuleName)
+	assert.Equal(t, "Alert limit reached", alert.Message)
+
+}
+
+func TestSendMalwareAlertHTTPExporter(t *testing.T) {
+	bodyChan := make(chan []byte, 1)
+	// Create a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Failed to read request body: %v", err)
+		}
+		bodyChan <- body
+	}))
+	defer server.Close()
+
+	// Create an HTTPExporter with the mock server URL
+	exporter, err := InitHTTPExporter(HTTPExporterConfig{
+		URL: server.URL,
+	})
+	assert.NoError(t, err)
+
+	// Create a mock malware description
+	malwareDesc := scan.MalwareDescription{
+		Name:           "testmalware",
+		Description:    "testmalwaredescription",
+		Path:           "testmalwarepath",
+		Hash:           "testmalwarehash",
+		Size:           "2MiB",
+		Resource:       schema.EmptyObjectKind.GroupVersionKind().GroupVersion().WithResource("testmalwareresource"),
+		Namespace:      "testmalwarenamespace",
+		PodName:        "testmalwarepodname",
+		ContainerName:  "testmalwarecontainername",
+		ContainerID:    "testmalwarecontainerid",
+		IsPartOfImage:  true,
+		ContainerImage: "testmalwarecontainerimage",
+	}
+
+	// Call SendMalwareAlert
+	exporter.SendMalwareAlert(malwareDesc)
+
+	// Assert that the HTTP request was sent correctly
+	alertsList := HTTPAlertsList{}
+	select {
+	case body := <-bodyChan:
+		if err := json.Unmarshal(body, &alertsList); err != nil {
+			t.Fatalf("Failed to unmarshal request body: %v", err)
+		}
+
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Timed out waiting for request body")
+	}
+
+	// Assert other expectations
+	assert.Equal(t, "RuntimeAlerts", alertsList.Kind)
+	assert.Equal(t, "kubescape.io/v1", alertsList.ApiVersion)
+	assert.Equal(t, 1, len(alertsList.Spec.Alerts))
+	alert := alertsList.Spec.Alerts[0]
+	assert.Equal(t, "KubeCopMalwareDetected", alert.RuleName)
+	assert.Equal(t, "testmalwarecontainerid", alert.ContainerID)
+	assert.Equal(t, "testmalwarecontainername", alert.ContainerName)
+	assert.Equal(t, "testmalwarenamespace", alert.PodNamespace)
+	assert.Equal(t, "testmalwarepodname", alert.PodName)
+}
+
+func TestValidateHTTPExporterConfig(t *testing.T) {
+	// Test case: URL is empty
+	_, err := InitHTTPExporter(HTTPExporterConfig{})
+	assert.Error(t, err)
+
+	// Test case: URL is not empty
+	exp, err := InitHTTPExporter(HTTPExporterConfig{
+		URL: "http://localhost:9093",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "POST", exp.config.Method)
+	assert.Equal(t, 1, exp.config.TimeoutSeconds)
+	assert.Equal(t, 10000, exp.config.MaxAlertsPerMinute)
+	assert.Equal(t, map[string]string{}, exp.config.Headers)
+
+	// Test case: Method is PUT
+	exp, err = InitHTTPExporter(HTTPExporterConfig{
+		URL:                "http://localhost:9093",
+		Method:             "PUT",
+		TimeoutSeconds:     2,
+		MaxAlertsPerMinute: 20000,
+		Headers: map[string]string{
+			"Authorization": "Bearer token",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "PUT", exp.config.Method)
+	assert.Equal(t, 2, exp.config.TimeoutSeconds)
+	assert.Equal(t, 20000, exp.config.MaxAlertsPerMinute)
+	assert.Equal(t, map[string]string{"Authorization": "Bearer token"}, exp.config.Headers)
+
+	// Test case: Method is neither POST nor PUT
+	_, err = InitHTTPExporter(HTTPExporterConfig{
+		URL:    "http://localhost:9093",
+		Method: "DELETE",
+	})
+	assert.Error(t, err)
+
+}


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Implemented an `HTTPExporter` to send security alerts over HTTP.
  - Configurable via `HTTPExporterConfig` with URL, headers, timeout, method, and rate limit.
  - Supports sending rule-based alerts and malware detection alerts.
  - Includes rate limiting to control the number of alerts sent per minute.
- Added comprehensive unit tests for the new `HTTPExporter`.
  - Tests cover sending rule alerts, rate limiting behavior, and malware alert sending.
  - Configuration validation tests ensure proper setup of the exporter.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_exporter.go</strong><dd><code>Implement HTTP Exporter for Alerts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/exporters/http_exporter.go
<li>Introduced <code>HTTPExporter</code> for sending alerts over HTTP.<br> <li> Added <code>HTTPExporterConfig</code> to configure the HTTP exporter.<br> <li> Implemented methods for sending rule and malware alerts.<br> <li> Added rate limiting for alerts sent per minute.<br>


</details>
    

  </td>
  <td><a href="https:/armosec/kubecop/pull/186/files#diff-6e04fd42d767812ea2855370a21a524371930b320544c0ee0954e1500242fbbd">+262/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_exporter_test.go</strong><dd><code>Unit Tests for HTTP Exporter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/exporters/http_exporter_test.go
<li>Added unit tests for <code>HTTPExporter</code> functionalities.<br> <li> Tested sending rule alerts, handling rate limits, and sending malware <br>alerts.<br> <li> Validated HTTP exporter configuration.<br>


</details>
    

  </td>
  <td><a href="https:/armosec/kubecop/pull/186/files#diff-89585231dfa94efdc4cac61ef6426f59bf494acd49c810bb29d56e16574fd350">+231/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

