### PR TITLE
Add tolerations to controller-statefulset and deamonset

### DIFF
--- a/chart/kubecop/templates/controller-statefulset.yaml
+++ b/chart/kubecop/templates/controller-statefulset.yaml
@@ -52,3 +52,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}

--- a/chart/kubecop/templates/deamonset.yaml
+++ b/chart/kubecop/templates/deamonset.yaml
@@ -170,10 +170,7 @@ spec:
           readOnly: true
     {{- end }}
       tolerations:
-      - effect: NoSchedule
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
+        {{- toYaml .Values.tolerations | nindent 8 }}
       volumes:
       - name: host
         hostPath:

--- a/chart/kubecop/values.yaml
+++ b/chart/kubecop/values.yaml
@@ -92,7 +92,11 @@ securityContextNormal: {}
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists
 
 affinity:
   nodeAffinity:


### PR DESCRIPTION
## **User description**
Tolerations in workloads in the Helm chart were missing the ability to be controlled. In this PR I am adding this capability.


___

## **Type**
enhancement


___

## **Description**
- Introduced templating for tolerations in the Helm chart to support dynamic configuration.
- Replaced static tolerations in DaemonSet with a templated approach, allowing for customization through values.
- Defined default tolerations in `values.yaml` to ensure backward compatibility and provide a base configuration.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>controller-statefulset.yaml</strong><dd><code>Add Dynamic Tolerations to StatefulSet Template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chart/kubecop/templates/controller-statefulset.yaml
<li>Added templating for tolerations to allow dynamic configuration based <br>on values.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/187/files#diff-94879afdd23579720c115da5b7271da861315680ff43c4546e9ef87b19e35c9b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deamonset.yaml</strong><dd><code>Replace Static Tolerations with Templated Ones in DaemonSet</code></dd></summary>
<hr>

chart/kubecop/templates/deamonset.yaml
<li>Replaced static tolerations with templated tolerations to support <br>dynamic configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/187/files#diff-85e96503359a8117f75f7b5e72b88e65cad1abdd451b7ea40e1c199289434d39">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Define Default Tolerations in Values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chart/kubecop/values.yaml
- Defined default tolerations for NoSchedule and NoExecute effects.



</details>
    

  </td>
  <td><a href="https://github.com/armosec/kubecop/pull/187/files#diff-a76a9e679fe402f7217b3d2cef96f308de47dc05a8d4cd9b8920a9bf051e0180">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

